### PR TITLE
Fix various typos and dark blast titles.

### DIFF
--- a/json/Item_Addon_Leg.txt
+++ b/json/Item_Addon_Leg.txt
@@ -254,7 +254,7 @@
 	{
 		"assign": "53045",
 		"jp_text": "レッグ／ザンスラスタ",
-		"tr_text": "Leg/Zan Thrust",
+		"tr_text": "Leg/Zan Thruster",
 		"jp_explain": "脚部ユニット。先鋭な装甲で保護。\n射撃、光、闇属性への耐性と\n射撃防御を上昇させる。",
 		"tr_explain": ""
 	},

--- a/json/Item_Stack_LobbyAction.txt
+++ b/json/Item_Stack_LobbyAction.txt
@@ -3581,7 +3581,7 @@
 		"jp_text": "507「斜めポーズ」",
 		"tr_text": "507 \"Lean Pose\"",
 		"jp_explain": "ロビアク『斜めポーズ』\nを全キャラクターで使用可能になる。",
-		"tr_explain": "Unlocks the new lobby action\n\"Slanted Pose\"."
+		"tr_explain": "Unlocks the new lobby action\n\"Lean Pose\"."
 	},
 	{
 		"assign": "3230522",

--- a/json/Item_Stack_PaidPass.txt
+++ b/json/Item_Stack_PaidPass.txt
@@ -1507,7 +1507,7 @@
 	{
 		"assign": "3210291",
 		"jp_text": "特殊能力（ＨＰ＆ＰＰ/３）",
-		"tr_text": "Add Ability (Stamina&PP/3)",
+		"tr_text": "Add Ability (HP&PP/3)",
 		"jp_explain": "特殊能力合成用の能力付与素材。\n特殊能力合成時に使用することで\n【ＨＰ＆ＰＰ/３】の特殊能力を追加する。",
 		"tr_explain": "Material used in Special Ability\nSynthesis. Grants \"Grace Stamina\"\nwhen used in Ability Synthesis."
 	},

--- a/json/Item_Weapon_DoubleSaber.txt
+++ b/json/Item_Weapon_DoubleSaber.txt
@@ -1164,7 +1164,7 @@
 	{
 		"assign": "150279",
 		"jp_text": "アレティアシフォス",
-		"tr_text": "Alethia Xiphos",
+		"tr_text": "Aletheia Xiphos",
 		"jp_explain": "古より伝わる陽光の両剣。\n聖なる光に授かりし尖鋭なる刃は\n生きし者全てを救け、静穏をもたらす。",
 		"tr_explain": ""
 	},

--- a/json/Title_All.txt
+++ b/json/Title_All.txt
@@ -2199,7 +2199,7 @@
 		"assign": "107000040",
 		"jp_text": "ダークブラスター",
 		"tr_text": "Dark Blaster",
-		"tr_explain": "Earn enough EXP to fully unlock\nDark Blast Elder Form"
+		"tr_explain": "Earn enough EXP to fully master\nDark Blast Elder Form"
 	},
 	{
 		"assign": "107000050",
@@ -2235,7 +2235,7 @@
 		"assign": "107001040",
 		"jp_text": "ダークブラスター【敗者】",
 		"tr_text": "Dark Blaster [Loser]",
-		"tr_explain": "Earn enough EXP to fully unlock\nDark Blast Loser Form"
+		"tr_explain": "Earn enough EXP to fully master\nDark Blast Loser Form"
 	},
 	{
 		"assign": "107001050",
@@ -2271,7 +2271,7 @@
 		"assign": "107002040",
 		"jp_text": "ダークブラスター【若人】",
 		"tr_text": "Dark Blaster [Apprentice]",
-		"tr_explain": "Earn enough EXP to fully unlock\nDark Blast Apprentice Form"
+		"tr_explain": "Earn enough EXP to fully master\nDark Blast Apprentice Form"
 	},
 	{
 		"assign": "107002050",
@@ -2307,7 +2307,7 @@
 		"assign": "107003040",
 		"jp_text": "ダークブラスター【双子】",
 		"tr_text": "Dark Blaster [Double]",
-		"tr_explain": "Earn enough EXP to fully unlock\nDark Blast Double Form"
+		"tr_explain": "Earn enough EXP to fully master\nDark Blast Double Form"
 	},
 	{
 		"assign": "107003050",


### PR DESCRIPTION
-Fix handful of typos across units, lobby action tickets, add ability, and weapons.
-Make Dark Blast full mastery titles clearer.