### PR TITLE
Various fixes

### DIFF
--- a/json/Explain_Element_Booster.txt
+++ b/json/Explain_Element_Booster.txt
@@ -1780,21 +1780,21 @@
 	{
 		"assign": "254",
 		"jp_text": "バトルＴマシンガンⅠ",
-		"tr_text": "Battle T. Machinegun I",
+		"tr_text": "Battle T. Machineguns I",
 		"jp_explain": "---",
 		"tr_explain": ""
 	},
 	{
 		"assign": "255",
 		"jp_text": "バトルＴマシンガンⅡ",
-		"tr_text": "Battle T. Machinegun II",
+		"tr_text": "Battle T. Machineguns II",
 		"jp_explain": "HP+50",
 		"tr_explain": "HP +50"
 	},
 	{
 		"assign": "256",
 		"jp_text": "バトルＴマシンガンⅢ",
-		"tr_text": "Battle T. Machinegun III",
+		"tr_text": "Battle T. Machineguns III",
 		"jp_explain": "HP+100",
 		"tr_explain": "HP +100"
 	},

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -478,9 +478,9 @@
 	{
 		"assign": "88",
 		"jp_text": "フレンズプロテクション",
-		"tr_text": "Friends' Protection",
+		"tr_text": "Friends Protection",
 		"jp_explain": "フレンズプロテクション\nイツキやRINA達との友情のリング\n被ダメージが減少する。",
-		"tr_explain": "Friends' Protection\nRing of friendship for Itsuki and RINA.\nReduces damage."
+		"tr_explain": "Friends Protection\nRing of friendship for Itsuki and RINA.\nReduces damage."
 	},
 	{
 		"assign": "70",
@@ -688,28 +688,28 @@
 	{
 		"assign": "2",
 		"jp_text": "Ｃストライク打撃",
-		"tr_text": "C-Strike - Striking",
+		"tr_text": "C Strike Striking",
 		"jp_explain": "クリティカルストライク打撃\nクリティカル率が上昇し、打撃攻撃の\nクリティカル時にダメージボーナスを得る。",
 		"tr_explain": "Critical Strike - Striking\nIncreases critical hit rate\nand boosts damage of Striking crits."
 	},
 	{
 		"assign": "3",
 		"jp_text": "Ｃストライク射撃",
-		"tr_text": "C-Strike - Ranged",
+		"tr_text": "C Strike Ranged",
 		"jp_explain": "クリティカルストライク射撃\nクリティカル率が上昇し、射撃攻撃の\nクリティカル時にダメージボーナスを得る。",
 		"tr_explain": "Critical Strike - Ranged\nIncreases critical hit rate\nand boosts damage of Ranged crits."
 	},
 	{
 		"assign": "4",
 		"jp_text": "Ｃストライク法撃",
-		"tr_text": "C-Strike - Technique",
+		"tr_text": "C Strike Technique",
 		"jp_explain": "クリティカルストライク法撃\nクリティカル率が上昇し、法撃攻撃の\nクリティカル時にダメージボーナスを得る。",
 		"tr_explain": "Critical Strike - Technique\nIncreases critical hit rate\nand boosts damage of Technique crits."
 	},
 	{
 		"assign": "103",
 		"jp_text": "Ｃストライク",
-		"tr_text": "C. Strike",
+		"tr_text": "C Strike",
 		"jp_explain": "クリティカルストライク\nクリティカル率が上昇し\nクリティカル時にダメージボーナスを得る。",
 		"tr_explain": "Critical Strike\nIncreases critical hit rate\nand boosts damage of crits."
 	},

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -16,28 +16,28 @@
 	{
 		"assign": "6",
 		"jp_text": "Ｐキーパー打撃",
-		"tr_text": "P. Keeper Striking",
+		"tr_text": "P Keeper Striking",
 		"jp_explain": "パーフェクトキーパー打撃\nＨＰが一定の割合以上のとき\nエネミーへの打撃攻撃のダメージが増加する。",
 		"tr_explain": "Perfect Keeper - Striking\nIncreases striking attack damage\nwhen HP is above a certain level."
 	},
 	{
 		"assign": "7",
 		"jp_text": "Ｐキーパー射撃",
-		"tr_text": "P. Keeper Ranged",
+		"tr_text": "P Keeper Ranged",
 		"jp_explain": "パーフェクトキーパー射撃\nＨＰが一定の割合以上のとき\nエネミーへの射撃攻撃のダメージが増加する。",
 		"tr_explain": "Perfect Keeper - Ranged\nIncreases ranged attack damage\nwhen HP is above a certain level."
 	},
 	{
 		"assign": "8",
 		"jp_text": "Ｐキーパー法撃",
-		"tr_text": "P. Keeper Technique",
+		"tr_text": "P Keeper Technique",
 		"jp_explain": "パーフェクトキーパー法撃\nＨＰが一定の割合以上のとき\nエネミーへの法撃攻撃のダメージが増加する。",
 		"tr_explain": "Perfect Keeper - Technique\nIncreases Technique attack damage\nwhen HP is above a certain level."
 	},
 	{
 		"assign": "104",
 		"jp_text": "Ｐキーパー",
-		"tr_text": "P. Keeper",
+		"tr_text": "P Keeper",
 		"jp_explain": "パーフェクトキーパー\nＨＰが一定の割合以上のとき\nエネミーへのダメージが増加する。",
 		"tr_explain": "Perfect Keeper\nIncreases all attack damage\nwhen HP is above a certain level."
 	},
@@ -268,7 +268,7 @@
 	{
 		"assign": "44",
 		"jp_text": "Ａランチャーモード",
-		"tr_text": "A Launcher Mode",
+		"tr_text": "A. Launcher Mode",
 		"jp_explain": "アナザーランチャーモード\nランチャーの通常攻撃の弾道が変化し\n威力が上昇。攻撃範囲も広がる。",
 		"tr_explain": "Another Launcher Mode Changes the\ntrajectory and boosts the power of a\nlauncher's normal attack. Attack\nrange is also increased."
 	},

--- a/json/Item_RingL.txt
+++ b/json/Item_RingL.txt
@@ -149,7 +149,7 @@
 	{
 		"assign": "151021",
 		"jp_text": "Ｌ／Ａランチャーモード",
-		"tr_text": "L/A Launcher Mode",
+		"tr_text": "L/A. Launcher Mode",
 		"jp_explain": "左手用。装備中は以下のスキルが有効。\n「アナザーランチャーモード」\n<yellow>※装備中に敵撃破でリングＥＸＰ獲得<c>",
 		"tr_explain": "Equipment for the Left Hand.\n\"A. Launcher Mode\"\n<yellow>※Ring EXP is\nawarded w/Enemy Kills<c>"
 	},

--- a/json/Item_Stack_DeviceTA.txt
+++ b/json/Item_Stack_DeviceTA.txt
@@ -4,118 +4,118 @@
 		"jp_text": "支援デバイス／ＨＰ回復Ａ",
 		"tr_text": "Support Device/HP Restore A",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n主人の体力低下時に回復支援を行う。\n発動率は高く、回復量が低い。",
-		"tr_explain": "A Mag support function device.\nProvides recovery when physical\nstrength is low. Low recovery."
+		"tr_explain": "A Mag support function device.\nRestores HP when health is low.\nHigh probability,\nbut low recovery."
 	},
 	{
 		"assign": "31101",
 		"jp_text": "支援デバイス／ＨＰ回復Ｂ",
 		"tr_text": "Support Device/HP Restore B",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n主人の体力低下時に回復支援を行う。\n発動率は普通で、回復量も普通。",
-		"tr_explain": "A Mag support function device.\nProvides recovery when physical\nstrength is low. Normal recovery."
+		"tr_explain": "A Mag support function device.\nRestores HP when health is low.\nAverage probability,\naverage recovery."
 	},
 	{
 		"assign": "31103",
 		"jp_text": "支援デバイス／能力上昇Ａ",
 		"tr_text": "Support Device/Stat Boost A",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nエリア変更時に能力上昇支援を行う。\n発動率は低く、インターバルは短い。",
-		"tr_explain": "A Mag support function device.\nProvides a boost to the user's skills\nupon area change at low intervals."
+		"tr_explain": "A Mag support function device.\nBuffs stats on area change.\nLow probability,\nshort duration."
 	},
 	{
 		"assign": "31104",
 		"jp_text": "支援デバイス／能力上昇Ｂ",
 		"tr_text": "Support Device/Stat Boost B",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nエリア変更時に能力上昇支援を行う。\n発動率は普通、インターバルも普通。",
-		"tr_explain": "A Mag support function device.\nProvides a boost to the user's skills\nupon area change at normal\nintervals."
+		"tr_explain": "A Mag support function device.\nBuffs stats on area change.\nAverage probability,\naverage duration."
 	},
 	{
 		"assign": "31106",
 		"jp_text": "支援デバイス／ＰＰ回復Ａ",
 		"tr_text": "Support Device/PP Restore A",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nエリア変更時にＰＰ回復支援を行う。\n発動率が高く、効果時間が短い。",
-		"tr_explain": "A Mag support function device.\nProvide PP recovery upon area\nchange at short but high intervals."
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration on area \nchange. High probability,\nbut short duration."
 	},
 	{
 		"assign": "31107",
 		"jp_text": "支援デバイス／ＰＰ回復Ｂ",
 		"tr_text": "Support Device/PP Restore B",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nエリア変更時にＰＰ回復支援を行う。\n発動率が普通、効果時間も普通。",
-		"tr_explain": "A Mag support function device.\nProvide PP recovery upon area\nchange at normal intervals."
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration on area \nchange. Average probability,\naverage duration."
 	},
 	{
 		"assign": "31109",
 		"jp_text": "支援デバイス／状態異常Ａ",
 		"tr_text": "Support Device/Status Heal A",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n状態異常時に異常回復支援を行う。\n発動率は低く、インターバルは短い。",
-		"tr_explain": "A Mag support function device.\nCures status effects at low\nintervals."
+		"tr_explain": "A Mag support function device.\nCures status ailments.\nLow probability,\nbut short cooldown."
 	},
 	{
 		"assign": "311010",
 		"jp_text": "支援デバイス／状態異常Ｂ",
 		"tr_text": "Support Device/Status Heal B",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n状態異常時に異常回復支援を行う。\n発動率が普通で、インターバルも普通。",
-		"tr_explain": "A Mag support function device.\nCures status effects at normal\nintervals."
+		"tr_explain": "A Mag support function device.\nCures status ailments.\nAverage probability,\naverage cooldown."
 	},
 	{
 		"assign": "311012",
 		"jp_text": "支援デバイス／無敵Ａ",
 		"tr_text": "Support Device/Invincibility A",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nＰＢゲージ満タン時に無敵支援を行う。\n効果時間が短い。",
-		"tr_explain": "A Mag support function device.\nProvides temporary invincibility\nwhen PB is charged."
+		"tr_explain": "A Mag support function device.\nProvides invincibility\nwhen PB gauge fills.\nShort duration."
 	},
 	{
 		"assign": "311016",
 		"jp_text": "支援デバイス／能力上昇Ｅ",
 		"tr_text": "Support Device/Stat Boost E",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nＰＢゲージ満タン時に能力上昇支援を\n行う。インターバルが普通。",
-		"tr_explain": "A Mag support function device.\nIncreases the user's abilities when\nPB is charged at normal intervals."
+		"tr_explain": "A Mag support function device.\nBuffs stats when PB gauge fills.\nAverage duration."
 	},
 	{
 		"assign": "311021",
 		"jp_text": "支援デバイス／能力上昇Ｇ",
 		"tr_text": "Support Device/Stat Boost G",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nＥトライアル時に能力上昇支援を行う。\n発動率は低く、インターバルは短い。",
-		"tr_explain": "A Mag support function device.\nIncreases the user's abilities at the\nstart of an E-Trial at low intervals."
+		"tr_explain": "A Mag support function device.\nBuffs stats when starting\nan Emergency Trial.\nLow probability and short cooldown."
 	},
 	{
 		"assign": "311022",
 		"jp_text": "支援デバイス／能力上昇Ｈ",
 		"tr_text": "Support Device/Stat Boost H",
 		"jp_explain": "マグの支援機能を設定するデバイス。\nＥトライアル時に能力上昇支援を行う。\n発動率は普通、インターバルも普通。",
-		"tr_explain": "A Mag support function device.\nIncreases the user's abilities at the\nstart of an E-Trial regularly."
+		"tr_explain": "A Mag support function device.\nBuffs stats when starting\nan Emergency Trial.\nAverage probability and cooldown."
 	},
 	{
 		"assign": "311027",
 		"jp_text": "支援デバイス／復活Ａ",
 		"tr_text": "Support Device/Revival A",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n戦闘不能時に復活支援を行う。\n発動は非常に稀。",
-		"tr_explain": "A Mag support function device.\nRevives the user upon a fatal blow.\nActivation of this function is rare."
+		"tr_explain": "A Mag support function device.\nRevives owner upon incapacitation.\nVery low probability."
 	},
 	{
 		"assign": "311030",
 		"jp_text": "支援デバイス／ＨＰ回復Ｋ",
 		"tr_text": "Support Device/HP Restore K",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n一定間隔でＨＰ回復支援を行う。\n間隔が普通で、回復量も普通。",
-		"tr_explain": "A Mag support function device.\nRecovers HP at regular set intervals."
+		"tr_explain": "A Mag support function device.\nRecovers HP at fixed intervals.\nAverage intervals and recovery."
 	},
 	{
 		"assign": "311033",
 		"jp_text": "支援デバイス／能力上昇Ｋ",
 		"tr_text": "Support Device/Stat Boost K",
 		"jp_explain": "マグの支援機能を設定するデバイス。\n一定間隔で能力上昇支援を行う。\n間隔が普通。",
-		"tr_explain": "A Mag support function device.\nIncreases the user's abilities at\nnormal set intervals."
+		"tr_explain": "A Mag support function device.\nBuffs stats at fixed intervals.\nAverage intervals."
 	},
 	{
 		"assign": "311038",
 		"jp_text": "生産デバイス／ＨＰ回復系",
 		"tr_text": "Production Device/Mates",
 		"jp_explain": "マグの生産機能を設定するデバイス。\n一定時間経過でモノメイトなどの\n消費系アイテムを生産する。",
-		"tr_explain": "A Mag production function device.\nProduces items, such as a\nMonomate, over time."
+		"tr_explain": "A Mag production function device.\nProduces healing items such as \nMonomates at fixed intervals."
 	},
 	{
 		"assign": "311039",
 		"jp_text": "生産デバイス／範囲系",
-		"tr_text": "Production Device/Mizers",
+		"tr_text": "Production Device/Atomizers",
 		"jp_explain": "マグの生産機能を設定するデバイス。\n一定時間経過でソルアトマイザーなどの\n消費系アイテムを生産する。",
-		"tr_explain": "A Mag production function device.\nProduces items, such as a\nSol Atomizer, over time."
+		"tr_explain": "A Mag production function device.\nProduces healing items such as \nSol Atomizers at fixed intervals."
 	}
 ]

--- a/json/Item_Stack_Roomgoods.txt
+++ b/json/Item_Stack_Roomgoods.txt
@@ -2816,28 +2816,28 @@
 	{
 		"assign": "350429",
 		"jp_text": "２０１３地区優勝記念品",
-		"tr_text": "",
+		"tr_text": "2013 District Champion Souvenir",
 		"jp_explain": "２０１３年アークス感謝祭\n地区大会優勝記念の記念品。\n優勝おめでとう！　次は全国だ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "350430",
 		"jp_text": "２０１３地区準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2013 District Runner-up Souvenir",
 		"jp_explain": "２０１３年アークス感謝祭\n地区大会準優勝記念の記念品。\n見事な成績！　次こそリベンジを！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "350432",
 		"jp_text": "２０１３全国優勝記念品",
-		"tr_text": "",
+		"tr_text": "2013 National Champion Souvenir",
 		"jp_explain": "２０１３年アークス感謝祭\n全国大会、優勝記念品！\nあなたが、ナンバーワンだ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "350433",
 		"jp_text": "２０１３全国準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2013 National Runner-up Souvenir",
 		"jp_explain": "２０１３年アークス感謝祭\n全国大会、準優勝記念品！\n次こそ目指せ、ナンバーワン！",
 		"tr_explain": ""
 	},
@@ -4601,28 +4601,28 @@
 	{
 		"assign": "350739",
 		"jp_text": "２０１４地区優勝記念品",
-		"tr_text": "",
+		"tr_text": "2014 District Champion Souvenir",
 		"jp_explain": "２０１４年アークス感謝祭\n地区大会優勝記念の記念品。\n優勝おめでとう！　次は全国だ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "350740",
 		"jp_text": "２０１４地区準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2014 District Runner-up Souvenir",
 		"jp_explain": "２０１４年アークス感謝祭\n地区大会準優勝記念の記念品。\n見事な成績！　次こそリベンジを！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "350741",
 		"jp_text": "２０１４全国優勝記念品",
-		"tr_text": "",
+		"tr_text": "2014 National Champion Souvenir",
 		"jp_explain": "２０１４年アークス感謝祭\n全国大会、優勝記念品！\nあなたが、ナンバーワンだ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "350742",
 		"jp_text": "２０１４全国準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2014 National Runner-up Souvenir",
 		"jp_explain": "２０１４年アークス感謝祭\n全国大会、準優勝記念品！\n次こそ目指せ、ナンバーワン！",
 		"tr_explain": ""
 	},
@@ -7023,28 +7023,28 @@
 	{
 		"assign": "3501092",
 		"jp_text": "２０１６地区優勝記念品",
-		"tr_text": "",
+		"tr_text": "2016 District Champion Souvenir",
 		"jp_explain": "２０１６年アークス感謝祭\n地区大会優勝記念の記念品。\n優勝おめでとう！　次は全国だ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501093",
 		"jp_text": "２０１６地区準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2016 District Runner-up Souvenir",
 		"jp_explain": "２０１６年アークス感謝祭\n地区大会準優勝記念の記念品。\n見事な成績！　次こそリベンジを！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501094",
 		"jp_text": "２０１６全国優勝記念品",
-		"tr_text": "",
+		"tr_text": "2016 National Champion Souvenir",
 		"jp_explain": "２０１６年アークス感謝祭\n全国大会、優勝記念品！\nあなたが、ナンバーワンだ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501095",
 		"jp_text": "２０１６全国準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2016 National Runner-up Souvenir",
 		"jp_explain": "２０１６年アークス感謝祭\n全国大会、準優勝記念品！\n次こそ目指せ、ナンバーワン！",
 		"tr_explain": ""
 	},
@@ -9270,14 +9270,14 @@
 	{
 		"assign": "3501447",
 		"jp_text": "２０１７地区優勝記念品",
-		"tr_text": "",
+		"tr_text": "2017 District Champion Souvenir",
 		"jp_explain": "２０１７年アークスバトルトーナメント\n地区大会優勝記念の記念品。\n優勝おめでとう！　次は全国だ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501448",
 		"jp_text": "２０１７地区準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2017 District Runner-up Souvenir",
 		"jp_explain": "２０１７年アークスバトルトーナメント\n地区大会準優勝記念の記念品。\n見事な成績！　次こそリベンジを！",
 		"tr_explain": ""
 	},
@@ -9347,14 +9347,14 @@
 	{
 		"assign": "3501459",
 		"jp_text": "２０１７全国優勝記念品",
-		"tr_text": "",
+		"tr_text": "2017 National Champion Souvenir",
 		"jp_explain": "２０１７年アークスバトルトーナメント\n全国大会、優勝記念品！\nあなたが、ナンバーワンだ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501460",
 		"jp_text": "２０１７全国準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2017 National Runner-up Souvenir",
 		"jp_explain": "２０１７年アークスバトルトーナメント\n全国大会、準優勝記念品！\n次こそ目指せ、ナンバーワン！",
 		"tr_explain": ""
 	},
@@ -10978,28 +10978,28 @@
 	{
 		"assign": "3501742",
 		"jp_text": "２０１９地区優勝記念品",
-		"tr_text": "",
+		"tr_text": "2019 District Champion Souvenir",
 		"jp_explain": "２０１９年アークスバトルトーナメント\n地区大会優勝記念の記念品。\n優勝おめでとう！　次は全国だ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501743",
 		"jp_text": "２０１９地区準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2019 District Runner-up Souvenir",
 		"jp_explain": "２０１９年アークスバトルトーナメント\n地区大会準優勝記念の記念品。\n見事な成績！　次こそリベンジを！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501744",
 		"jp_text": "２０１９全国優勝記念品",
-		"tr_text": "",
+		"tr_text": "2019 National Champion Souvenir",
 		"jp_explain": "２０１９年アークスバトルトーナメント\n全国大会、優勝記念品！\nあなたが、ナンバーワンだ！",
 		"tr_explain": ""
 	},
 	{
 		"assign": "3501745",
 		"jp_text": "２０１９全国準優勝記念品",
-		"tr_text": "",
+		"tr_text": "2019 National Runner-up Souvenir",
 		"jp_explain": "２０１９年アークスバトルトーナメント\n全国大会、準優勝記念品！\n次こそ目指せ、ナンバーワン！",
 		"tr_explain": ""
 	},

--- a/json/Item_Stack_Tool.txt
+++ b/json/Item_Stack_Tool.txt
@@ -79,9 +79,9 @@
 	{
 		"assign": "37011",
 		"jp_text": "スケープドール",
-		"tr_text": "Scapedoll",
+		"tr_text": "Scape Doll",
 		"jp_explain": "自律起動の自己復活用アイテム。\n所持者が戦闘不能になった際に\n一度だけ身代わりになってくれる。",
-		"tr_explain": "Recovery medicine for ARKS.\nRevives the user to maximum Health."
+		"tr_explain": "A self-revival item. When you\nbecome incapacitated, you can use\nthis substitute instead of yourself."
 	},
 	{
 		"assign": "37012",
@@ -114,7 +114,7 @@
 	{
 		"assign": "37016",
 		"jp_text": "ハーフドール",
-		"tr_text": "Halfdoll",
+		"tr_text": "Half Doll",
 		"jp_explain": "自律起動の自己復活用アイテム。\n所持者が戦闘不能になった際に\n一度だけ身代わりになってくれる。",
 		"tr_explain": "A self-revival item. When you\nbecome incapacitated, you can use\nthis substitute instead of yourself."
 	},
@@ -270,7 +270,7 @@
 		"jp_text": "チャレンジドール",
 		"tr_text": "Challenge Doll",
 		"jp_explain": "自律起動の自己復活用アイテム。\n所持者が戦闘不能になった際に\n一度だけ身代わりになってくれる。",
-		"tr_explain": "Self-recovery item that activates\nautomatically. Will activate once\nwhen its owner is defeated."
+		"tr_explain": "A self-revival item. When you\nbecome incapacitated, you can use\nthis substitute instead of yourself."
 	},
 	{
 		"assign": "37044",

--- a/json/Item_Weapon_AssaultRifle.txt
+++ b/json/Item_Weapon_AssaultRifle.txt
@@ -1430,7 +1430,7 @@
 	{
 		"assign": "180343",
 		"jp_text": "Ｚｉｇ　ランチャーＬｖ３",
-		"tr_text": "Zig Launcher Lv3",
+		"tr_text": "Zig Launcher Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた長銃。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_DualBlade.txt
+++ b/json/Item_Weapon_DualBlade.txt
@@ -1073,21 +1073,21 @@
 	{
 		"assign": "1170298",
 		"jp_text": "バトルＤブレードＬｖ１",
-		"tr_text": "Battle D. Blades Lv1",
+		"tr_text": "Battle D. Blades Lv.1",
 		"jp_explain": "バトルアリーナ用に調整された飛翔剣。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1170299",
 		"jp_text": "バトルＤブレードＬｖ２",
-		"tr_text": "Battle D. Blades Lv2",
+		"tr_text": "Battle D. Blades Lv.2",
 		"jp_explain": "バトルアリーナ用に調整された飛翔剣。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1170300",
 		"jp_text": "バトルＤブレードＬｖ３",
-		"tr_text": "Battle D. Blades Lv3",
+		"tr_text": "Battle D. Blades Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた飛翔剣。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_DualBlade.txt
+++ b/json/Item_Weapon_DualBlade.txt
@@ -1073,21 +1073,21 @@
 	{
 		"assign": "1170298",
 		"jp_text": "バトルＤブレードＬｖ１",
-		"tr_text": "Battle D. Blade Lv1",
+		"tr_text": "Battle D. Blades Lv1",
 		"jp_explain": "バトルアリーナ用に調整された飛翔剣。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1170299",
 		"jp_text": "バトルＤブレードＬｖ２",
-		"tr_text": "Battle D. Blade Lv2",
+		"tr_text": "Battle D. Blades Lv2",
 		"jp_explain": "バトルアリーナ用に調整された飛翔剣。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1170300",
 		"jp_text": "バトルＤブレードＬｖ３",
-		"tr_text": "Battle D. Blade Lv3",
+		"tr_text": "Battle D. Blades Lv3",
 		"jp_explain": "バトルアリーナ専用に作られた飛翔剣。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_GunSlash.txt
+++ b/json/Item_Weapon_GunSlash.txt
@@ -431,7 +431,7 @@
 		"jp_text": "ステルスウェポン：ＧＳ",
 		"tr_text": "Stealth Weapon: GS",
 		"jp_explain": "認識不能な武器。\n形状はガンスラッシュ型。",
-		"tr_explain": "Unknown Weapon. Seems to\nbe in the shape of a Gunslash."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Gunslash."
 	},
 	{
 		"assign": "17076",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -403,7 +403,7 @@
 		"jp_text": "ステルスウェポン：ＫＮ",
 		"tr_text": "Stealth Weapon: KN",
 		"jp_explain": "認識不能な武器。\n形状はナックル型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na pair of knuckles."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na pair of Knuckles."
 	},
 	{
 		"assign": "16068",

--- a/json/Item_Weapon_Knuckle.txt
+++ b/json/Item_Weapon_Knuckle.txt
@@ -1199,21 +1199,21 @@
 	{
 		"assign": "160268",
 		"jp_text": "バトルナックルＬｖ１",
-		"tr_text": "Battle Knuckle Lv.1",
+		"tr_text": "Battle Knuckles Lv.1",
 		"jp_explain": "バトルアリーナ用に調整された鋼拳。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "160269",
 		"jp_text": "バトルナックルＬｖ２",
-		"tr_text": "Battle Knuckle Lv.2",
+		"tr_text": "Battle Knuckles Lv.2",
 		"jp_explain": "バトルアリーナ用に調整された鋼拳。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "160270",
 		"jp_text": "バトルナックルＬｖ３",
-		"tr_text": "Battle Knuckle Lv.3",
+		"tr_text": "Battle Knuckles Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた鋼拳。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Partizan.txt
+++ b/json/Item_Weapon_Partizan.txt
@@ -403,7 +403,7 @@
 		"jp_text": "ステルスウェポン：ＰＲ",
 		"tr_text": "Stealth Weapon: PR",
 		"jp_explain": "認識不能な武器。\n形状はパルチザン型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of the Partizan-type."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Partizan."
 	},
 	{
 		"assign": "13069",

--- a/json/Item_Weapon_Rod.txt
+++ b/json/Item_Weapon_Rod.txt
@@ -464,9 +464,9 @@
 	{
 		"assign": "111072",
 		"jp_text": "ステルスウェポン：ＲＯ",
-		"tr_text": "Stealth Weapon:RO",
+		"tr_text": "Stealth Weapon: RO",
 		"jp_explain": "認識不能な武器。\n形状はロッド型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of the Rod-type."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Rod."
 	},
 	{
 		"assign": "111073",

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -1479,7 +1479,7 @@
 	{
 		"assign": "110398",
 		"jp_text": "スライプナーＬｖ３",
-		"tr_text": "Sleipnir Lv3",
+		"tr_text": "Sleipnir Lv.3",
 		"jp_explain": "バトルアリーナ用に調整された大剣。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Sword.txt
+++ b/json/Item_Weapon_Sword.txt
@@ -445,7 +445,7 @@
 		"jp_text": "ステルスウェポン：SW",
 		"tr_text": "Stealth Weapon: SW",
 		"jp_explain": "認識不能な武器。\n形状はソード型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of the Sword-type."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Sword."
 	},
 	{
 		"assign": "11070",

--- a/json/Item_Weapon_Talis.txt
+++ b/json/Item_Weapon_Talis.txt
@@ -424,7 +424,7 @@
 		"jp_text": "ステルスウェポン：ＴＡ",
 		"tr_text": "Stealth Weapon: TA",
 		"jp_explain": "認識不能な武器。\n形状はタリス型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of the Talis-type."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Talis."
 	},
 	{
 		"assign": "112083",

--- a/json/Item_Weapon_Talis.txt
+++ b/json/Item_Weapon_Talis.txt
@@ -1297,21 +1297,21 @@
 	{
 		"assign": "1120298",
 		"jp_text": "バトルタリスＬｖ１",
-		"tr_text": "Battle Talis Lv1",
+		"tr_text": "Battle Talis Lv.1",
 		"jp_explain": "バトルアリーナ用に調整された導具。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1120299",
 		"jp_text": "バトルタリスＬｖ２",
-		"tr_text": "Battle Talis Lv2",
+		"tr_text": "Battle Talis Lv.2",
 		"jp_explain": "バトルアリーナ用に調整された導具。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1120300",
 		"jp_text": "バトルタリスＬｖ３",
-		"tr_text": "Battle Talis Lv3",
+		"tr_text": "Battle Talis Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた導具。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -415,9 +415,9 @@
 	{
 		"assign": "14069",
 		"jp_text": "ステルスウェポン：ＴＤ",
-		"tr_text": "Stealth Weapon:TD",
+		"tr_text": "Stealth Weapon: TD",
 		"jp_explain": "認識不能な武器。\n形状はツインダガー型。",
-		"tr_explain": ""
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Twin Dagger."
 	},
 	{
 		"assign": "14070",

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -1213,21 +1213,21 @@
 	{
 		"assign": "140293",
 		"jp_text": "バトルＴダガーＬｖ１",
-		"tr_text": "Battle T. Dagger Lv1",
+		"tr_text": "Battle T. Daggers Lv1",
 		"jp_explain": "バトルアリーナ用に調整された双小剣。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "140294",
 		"jp_text": "バトルＴダガーＬｖ２",
-		"tr_text": "Battle T. Dagger Lv2",
+		"tr_text": "Battle T. Daggers Lv2",
 		"jp_explain": "バトルアリーナ用に調整された双小剣。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "140295",
 		"jp_text": "バトルＴダガーＬｖ３",
-		"tr_text": "Battle T. Dagger Lv3",
+		"tr_text": "Battle T. Daggers Lv3",
 		"jp_explain": "バトルアリーナ専用に作られた双小剣。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_TwinDagger.txt
+++ b/json/Item_Weapon_TwinDagger.txt
@@ -1213,21 +1213,21 @@
 	{
 		"assign": "140293",
 		"jp_text": "バトルＴダガーＬｖ１",
-		"tr_text": "Battle T. Daggers Lv1",
+		"tr_text": "Battle T. Daggers Lv.1",
 		"jp_explain": "バトルアリーナ用に調整された双小剣。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "140294",
 		"jp_text": "バトルＴダガーＬｖ２",
-		"tr_text": "Battle T. Daggers Lv2",
+		"tr_text": "Battle T. Daggers Lv.2",
 		"jp_explain": "バトルアリーナ用に調整された双小剣。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "140295",
 		"jp_text": "バトルＴダガーＬｖ３",
-		"tr_text": "Battle T. Daggers Lv3",
+		"tr_text": "Battle T. Daggers Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた双小剣。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -352,7 +352,7 @@
 	{
 		"assign": "110052",
 		"jp_text": "スパルマシンガン",
-		"tr_text": "Sparmachinegun",
+		"tr_text": "Sparmachineguns",
 		"jp_explain": "機甲種の部品を再利用した双機銃。\n精密なつくりによって、集弾性が高く\nまとまった仕上がりとなっている。",
 		"tr_explain": ""
 	},
@@ -1430,14 +1430,14 @@
 	{
 		"assign": "1100345",
 		"jp_text": "ノヴェルＴマシンガン",
-		"tr_text": "Novel T. Machinegun",
+		"tr_text": "Novel T. Machineguns",
 		"jp_explain": "新技術により開発された双機銃。\n次期主力を担う武器として作られた。\n一部の機能が制限されている。",
 		"tr_explain": "Machineguns made with new tech\nto be the next-gen main weapon.\nThey seem to have a hard cover."
 	},
 	{
 		"assign": "1100346",
 		"jp_text": "リバレイトＴマシンガン",
-		"tr_text": "Liberate T. Machinegun",
+		"tr_text": "Liberate T. Machineguns",
 		"jp_explain": "新技術により開発された双機銃。\n次期主力を担う武器の真なる姿。\n優れた連射性能と高い安定性を持つ。",
 		"tr_explain": "Machineguns made with new tech.\nThe true form of the next-gen\nweapon, high in power and stability."
 	},

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -1444,21 +1444,21 @@
 	{
 		"assign": "1100349",
 		"jp_text": "バトルＴマシンガンＬｖ１",
-		"tr_text": "Battle T. Machinegun Lv.1",
+		"tr_text": "Battle T. Machineguns Lv.1",
 		"jp_explain": "バトルアリーナ用に調整された双機銃。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1100350",
 		"jp_text": "バトルＴマシンガンＬｖ２",
-		"tr_text": "Battle T. Machinegun Lv.2",
+		"tr_text": "Battle T. Machineguns Lv.2",
 		"jp_explain": "バトルアリーナ用に調整された双機銃。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1100351",
 		"jp_text": "バトルＴマシンガンＬｖ３",
-		"tr_text": "Battle T. Machinegun Lv.3",
+		"tr_text": "Battle T. Machineguns Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた双機銃。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -466,7 +466,7 @@
 		"jp_text": "ステルスウェポン：ＴＭ",
 		"tr_text": "Stealth Weapon: TM",
 		"jp_explain": "認識不能な武器。\n形状はツインマシンガン型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of the TMG-type"
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Twin Machinegun."
 	},
 	{
 		"assign": "110074",

--- a/json/Item_Weapon_TwinMachineGun.txt
+++ b/json/Item_Weapon_TwinMachineGun.txt
@@ -1444,21 +1444,21 @@
 	{
 		"assign": "1100349",
 		"jp_text": "バトルＴマシンガンＬｖ１",
-		"tr_text": "Battle T-Machinegun Lv.1",
+		"tr_text": "Battle T. Machinegun Lv.1",
 		"jp_explain": "バトルアリーナ用に調整された双機銃。\n純粋に技を競うため基本性能のみを\n強化している。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1100350",
 		"jp_text": "バトルＴマシンガンＬｖ２",
-		"tr_text": "Battle T-Machinegun Lv.2",
+		"tr_text": "Battle T. Machinegun Lv.2",
 		"jp_explain": "バトルアリーナ用に調整された双機銃。\n戦技比較が目的となるため\n基本性能の強化にとどまっている。",
 		"tr_explain": ""
 	},
 	{
 		"assign": "1100351",
 		"jp_text": "バトルＴマシンガンＬｖ３",
-		"tr_text": "Battle T-Machinegun Lv.3",
+		"tr_text": "Battle T. Machinegun Lv.3",
 		"jp_explain": "バトルアリーナ専用に作られた双機銃。\n戦技比較用に特化しており、力量が\nより発揮される調整となっている。",
 		"tr_explain": ""
 	},

--- a/json/Item_Weapon_Wand.txt
+++ b/json/Item_Weapon_Wand.txt
@@ -403,7 +403,7 @@
 		"jp_text": "ステルスウェポン：ＷＡ",
 		"tr_text": "Stealth Weapon: WA",
 		"jp_explain": "認識不能な武器。\n形状はウォンド型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of the Wand-type."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Wand."
 	},
 	{
 		"assign": "113067",

--- a/json/Item_Weapon_WiredLance.txt
+++ b/json/Item_Weapon_WiredLance.txt
@@ -438,7 +438,7 @@
 		"jp_text": "ステルスウェポン：ＷＬ",
 		"tr_text": "Stealth Weapon: WL",
 		"jp_explain": "認識不能な武器。\n形状はワイヤードランス型。",
-		"tr_explain": "Unknown Weapon.\nSeems to be of a Wired Lance-type."
+		"tr_explain": "Unknown Weapon.\nSeems to be in the shape of\na Wired Lance."
 	},
 	{
 		"assign": "12074",

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -169,7 +169,7 @@
 	},
 	{
 		"jp_text": "エルアーダの尻尾",
-		"tr_text": "El Ahda Tails",
+		"tr_text": "El Ahda Tail",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -435,7 +435,7 @@
 	},
 	{
 		"jp_text": "スライトリトル",
-		"tr_text": "M Slight Little M",
+		"tr_text": "Slight Little",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -771,7 +771,7 @@
 	},
 	{
 		"jp_text": "プ㾛プレミアムセット３０日",
-		"tr_text": "Premium 30 day",
+		"tr_text": "Premium 30 days",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -799,7 +799,7 @@
 	},
 	{
 		"jp_text": "ラウンドサングラス頭の上",
-		"tr_text": "Round Sunglasses on Head",
+		"tr_text": "On-Head Round Sunglasses",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -2087,7 +2087,7 @@
 	},
 	{
 		"jp_text": "Ｒ／テストリング",
-		"tr_text": "R / Test Ring",
+		"tr_text": "R/Test Ring",
 		"jp_explain": "",
 		"tr_explain": "Equipment for the Right Hand.\nTransaction Test Ring.",
 		"assign": 0

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -672,13 +672,6 @@
 		"assign": 0
 	},
 	{
-		"jp_text": "パニッシュアロウ",
-		"tr_text": "Banish Arrow",
-		"jp_explain": "",
-		"tr_explain": "",
-		"assign": 0
-	},
-	{
 		"jp_text": "パルチザンギア",
 		"tr_text": "Partizan Gear",
 		"jp_explain": "",
@@ -2006,13 +1999,6 @@
 		"tr_text": "Heterogeneous Tainted Core",
 		"jp_explain": "",
 		"tr_explain": "",
-		"assign": 0
-	},
-	{
-		"jp_text": "魂を捧げしもの",
-		"tr_text": "Sacrificer of Souls",
-		"jp_explain": "",
-		"tr_explain": "Grind Soul Eater to +10",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -133,13 +133,6 @@
 		"assign": 0
 	},
 	{
-		"jp_text": "ウィザードぺタソス",
-		"tr_text": "Wizard's Petasos (Duplicate)",
-		"jp_explain": "",
-		"tr_explain": "Unlocks the hairstyle\n\"Wizard's Petasos\"\nfor use in the Beauty Salon.",
-		"assign": 0
-	},
-	{
 		"jp_text": "ウィークスタンス",
 		"tr_text": "Weak Stance",
 		"jp_explain": "",

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -1375,7 +1375,7 @@
 		"jp_text": "支援デバイス／ＰＰ回復Ｃ",
 		"tr_text": "Support Device/PP Restore C",
 		"jp_explain": "",
-		"tr_explain": "A Mag support function device.\nBoosts PP regeneration on area \nchange. Low probability,\nbut long duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration on area\nchange. Low probability,\nbut long duration.",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -374,7 +374,7 @@
 		"jp_text": "ジェルンショット",
 		"tr_text": "Jellen Shot",
 		"jp_explain": "",
-		"tr_explain": "Loads Jellen ammo that\nlowers enemy attack power.",
+		"tr_explain": "Launchers only.\nLoads Jellen ammo that\nlowers enemy attack power.",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -841,7 +841,7 @@
 	},
 	{
 		"jp_text": "リア／ファーレンマーメ",
-		"tr_text": "Rear / Fahrenmarme",
+		"tr_text": "Rear/Fahrenmarme",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -1081,98 +1081,98 @@
 		"jp_text": "女性ユニークボイス０１",
 		"tr_text": "Female Unique Voice 01",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 01\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０２",
 		"tr_text": "Female Unique Voice 02",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 02\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０３",
 		"tr_text": "Female Unique Voice 03",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 03\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０４",
 		"tr_text": "Female Unique Voice 04",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 04\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０５",
 		"tr_text": "Female Unique Voice 05",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 05\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０６",
 		"tr_text": "Female Unique Voice 06",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 06\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０７",
 		"tr_text": "Female Unique Voice 07",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 07\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０８",
 		"tr_text": "Female Unique Voice 08",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 08\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス０９",
 		"tr_text": "Female Unique Voice 09",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 09\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス１０",
 		"tr_text": "Female Unique Voice 10",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 10\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス１１",
 		"tr_text": "Female Unique Voice 11",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 11\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス１２",
 		"tr_text": "Female Unique Voice 12",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 12\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス１３",
 		"tr_text": "Female Unique Voice 13",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 13\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性ユニークボイス１４",
 		"tr_text": "Female Unique Voice 14",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female Unique Voice 14\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
@@ -1200,98 +1200,98 @@
 		"jp_text": "女性Ｃユニークボイス０１",
 		"tr_text": "Female C Unique Voice 01",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 01\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０２",
 		"tr_text": "Female C Unique Voice 02",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 02\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０３",
 		"tr_text": "Female C Unique Voice 03",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 03\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０４",
 		"tr_text": "Female C Unique Voice 04",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 04\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０５",
 		"tr_text": "Female C Unique Voice 05",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 05\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０６",
 		"tr_text": "Female C Unique Voice 06",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 06\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０７",
 		"tr_text": "Female C Unique Voice 07",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 07\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０８",
 		"tr_text": "Female C Unique Voice 08",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 08\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス０９",
 		"tr_text": "Female C Unique Voice 09",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 09\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス１０",
 		"tr_text": "Female C Unique Voice 10",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 10\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス１１",
 		"tr_text": "Female C Unique Voice 11",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 11\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス１２",
 		"tr_text": "Female C Unique Voice 12",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 12\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス１３",
 		"tr_text": "Female C Unique Voice 13",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 13\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃユニークボイス１４",
 		"tr_text": "Female C Unique Voice 14",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Female C Unique Voice 14\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
@@ -1487,518 +1487,518 @@
 		"jp_text": "男性ユニークボイス０１",
 		"tr_text": "Male Unique Voice 01",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 01\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０２",
 		"tr_text": "Male Unique Voice 02",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 02\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０３",
 		"tr_text": "Male Unique Voice 03",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 03\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０４",
 		"tr_text": "Male Unique Voice 04",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 04\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０５",
 		"tr_text": "Male Unique Voice 05",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 05\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０６",
 		"tr_text": "Male Unique Voice 06",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 06\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０７",
 		"tr_text": "Male Unique Voice 07",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 07\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０８",
 		"tr_text": "Male Unique Voice 08",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 08\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス０９",
 		"tr_text": "Male Unique Voice 09",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 09\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス１０",
 		"tr_text": "Male Unique Voice 10",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 10\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス１１",
 		"tr_text": "Male Unique Voice 11",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 11\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス１２",
 		"tr_text": "Male Unique Voice 12",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 12\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス１３",
 		"tr_text": "Male Unique Voice 13",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 13\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性ユニークボイス１４",
 		"tr_text": "Male Unique Voice 14",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Unique Voice 14\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１７５",
 		"tr_text": "Male Extra Voice 175",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 175\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１７６",
 		"tr_text": "Male Extra Voice 176",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 176\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１７７",
 		"tr_text": "Male Extra Voice 177",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 177\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１７８",
 		"tr_text": "Male Extra Voice 178",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 178\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１７９",
 		"tr_text": "Male Extra Voice 179",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 179\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８０",
 		"tr_text": "Male Extra Voice 180",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 180\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８１",
 		"tr_text": "Male Extra Voice 181",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 181\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８２",
 		"tr_text": "Male Extra Voice 182",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 182\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８３",
 		"tr_text": "Male Extra Voice 183",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 183\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８４",
 		"tr_text": "Male Extra Voice 184",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 184\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８７",
 		"tr_text": "Male Extra Voice 187",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 187\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８８",
 		"tr_text": "Male Extra Voice 188",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 188\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１８９",
 		"tr_text": "Male Extra Voice 189",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 189\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９０",
 		"tr_text": "Male Extra Voice 190",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 190\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９１",
 		"tr_text": "Male Extra Voice 191",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 191\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９２",
 		"tr_text": "Male Extra Voice 192",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 192\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９３",
 		"tr_text": "Male Extra Voice 193",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 193\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９４",
 		"tr_text": "Male Extra Voice 194",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 194\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９５",
 		"tr_text": "Male Extra Voice 195",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 195\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９６",
 		"tr_text": "Male Extra Voice 196",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 196\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９７",
 		"tr_text": "Male Extra Voice 197",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 197\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９８",
 		"tr_text": "Male Extra Voice 198",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 198\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性追加ボイス１９９",
 		"tr_text": "Male Extra Voice 199",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male Extra Voice 199\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０１",
 		"tr_text": "Male C Unique Voice 01",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 01\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０２",
 		"tr_text": "Male C Unique Voice 02",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 02\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０３",
 		"tr_text": "Male C Unique Voice 03",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 03\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０４",
 		"tr_text": "Male C Unique Voice 04",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 04\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０５",
 		"tr_text": "Male C Unique Voice 05",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 05\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０６",
 		"tr_text": "Male C Unique Voice 06",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 06\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０７",
 		"tr_text": "Male C Unique Voice 07",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 07\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０８",
 		"tr_text": "Male C Unique Voice 08",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 08\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス０９",
 		"tr_text": "Male C Unique Voice 09",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 09\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス１０",
 		"tr_text": "Male C Unique Voice 10",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 10\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス１１",
 		"tr_text": "Male C Unique Voice 11",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 11\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス１２",
 		"tr_text": "Male C Unique Voice 12",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 12\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス１３",
 		"tr_text": "Male C Unique Voice 13",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 13\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃユニークボイス１４",
 		"tr_text": "Male C Unique Voice 14",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Unique Voice 14\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１７５",
 		"tr_text": "Male C Extra Voice 175",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 175\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１７６",
 		"tr_text": "Male C Extra Voice 176",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 176\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１７７",
 		"tr_text": "Male C Extra Voice 177",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 177\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１７８",
 		"tr_text": "Male C Extra Voice 178",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 178\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１７９",
 		"tr_text": "Male C Extra Voice 179",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 179\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８０",
 		"tr_text": "Male C Extra Voice 180",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 180\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８１",
 		"tr_text": "Male C Extra Voice 181",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 181\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８２",
 		"tr_text": "Male C Extra Voice 182",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 182\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８３",
 		"tr_text": "Male C Extra Voice 183",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 183\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８４",
 		"tr_text": "Male C Extra Voice 184",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 184\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８７",
 		"tr_text": "Male C Extra Voice 187",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 187\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８８",
 		"tr_text": "Male C Extra Voice 188",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 188\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１８９",
 		"tr_text": "Male C Extra Voice 189",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 189\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９０",
 		"tr_text": "Male C Extra Voice 190",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 190\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９１",
 		"tr_text": "Male C Extra Voice 191",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 191\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９２",
 		"tr_text": "Male C Extra Voice 192",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 192\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９３",
 		"tr_text": "Male C Extra Voice 193",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 193\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９４",
 		"tr_text": "Male C Extra Voice 194",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 194\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９５",
 		"tr_text": "Male C Extra Voice 195",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 195\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９６",
 		"tr_text": "Male C Extra Voice 196",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 196\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９７",
 		"tr_text": "Male C Extra Voice 197",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 197\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９８",
 		"tr_text": "Male C Extra Voice 198",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 198\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "男性Ｃ追加ボイス１９９",
 		"tr_text": "Male C Extra Voice 199",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the voice\n\"Male C Extra Voice 199\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -591,7 +591,7 @@
 		"jp_text": "トライブースト＋２５％",
 		"tr_text": "Tri-Boost +25%",
 		"jp_explain": "",
-		"tr_explain": "Boosts Meseta, Experience, and Rare\nDrop Rate by 25%. Duration lasts for\n30 minutes on the field.",
+		"tr_explain": "Boost item that boosts Rare Drop\nRate, Meseta, and EXP by 25%.\nLasts 30 minutes.",
 		"assign": 0
 	},
 	{
@@ -682,7 +682,7 @@
 		"jp_text": "パープルシュシュ",
 		"tr_text": "Purple Scrunchie",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the accessory\n\"Purple Scrunchie\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Unlocks the accessory\n\"Purple Scrunchie\"\nfor use in the Beauty Salon.",
 		"assign": 0
 	},
 	{
@@ -794,7 +794,7 @@
 		"jp_text": "ラウンドサングラス頭の上",
 		"tr_text": "On-Head Round Sunglasses",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Unlocks the accessory\n\"On-Head Round Sunglasses\"\nfor use in the Beauty Salon.",
 		"assign": 0
 	},
 	{
@@ -927,7 +927,7 @@
 		"jp_text": "リボンソックス＆手袋",
 		"tr_text": "Black Ribbon Socks & Gloves",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the body paint\n\"Black Ribbon Socks & Gloves\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Unlocks the body paint\n\"Black Ribbon Socks & Gloves\"\nfor use in the Beauty Salon.",
 		"assign": 0
 	},
 	{
@@ -2131,7 +2131,7 @@
 		"jp_text": "ｍａｉｍａｉユニット",
 		"tr_text": "Maimai Arcade Unit",
 		"jp_explain": "",
-		"tr_explain": "A decoration for My Room.\nAn imitation of a sensational rhythm\nvideogame. Functions similar to a\njukebox.",
+		"tr_explain": "A decoration for My Room.\nAn imitation of a sensational rhythm\nvideogame. Functions similarly to a\njukebox.",
 		"assign": 0
 	}
 ]

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -204,14 +204,14 @@
 	},
 	{
 		"jp_text": "エレメントウィークヒット",
-		"tr_text": "Elemental Weak Hit",
+		"tr_text": "Element Weak Hit",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
 	},
 	{
 		"jp_text": "エレメントコンバージョン",
-		"tr_text": "Elemental Conversion",
+		"tr_text": "Element Conversion",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -715,7 +715,7 @@
 	},
 	{
 		"jp_text": "フォトンＢフィーバーアップ",
-		"tr_text": "Photon Blade Fever Up",
+		"tr_text": "Photon Blade Fever Boost",
 		"jp_explain": "",
 		"tr_explain": "During Photon Blade Fever, increase\nPhoton Blade power.",
 		"assign": 0
@@ -813,7 +813,7 @@
 	},
 	{
 		"jp_text": "ラピッドシュート",
-		"tr_text": "Rapid Shoot",
+		"tr_text": "Rapid Shot",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -827,7 +827,7 @@
 	},
 	{
 		"jp_text": "ラピッドシュートマスタリー",
-		"tr_text": "Rapid Shoot Mastery",
+		"tr_text": "Rapid Shot Mastery",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -2031,7 +2031,7 @@
 	},
 	{
 		"jp_text": "ＤＳウィンドパリング",
-		"tr_text": "DS Wind Parry",
+		"tr_text": "Double Saber Wind Parry",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -2101,14 +2101,35 @@
 	},
 	{
 		"jp_text": "Ｔマシンガンマスタリー",
-		"tr_text": "T Machine Gun Mastery",
+		"tr_text": "Twin Machinegun Mastery",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
 	},
 	{
-		"jp_text": "ＶＤ「アポなし訪問録」",
-		"tr_text": "VD 「Aponashi Houmonroku」",
+		"jp_text": "クイックメイト",
+		"tr_text": "Quick Mate",
+		"jp_explain": "",
+		"tr_explain": "",
+		"assign": 0
+	},
+	{
+		"jp_text": "ボルトテックＰＰセイブ",
+		"tr_text": "Bolt Tech PP Save",
+		"jp_explain": "",
+		"tr_explain": "",
+		"assign": 0
+	},
+	{
+		"jp_text": "アタックアドバンス",
+		"tr_text": "Attack Advance",
+		"jp_explain": "",
+		"tr_explain": "",
+		"assign": 0
+	},
+	{
+		"jp_text": "ステップJAコンボ",
+		"tr_text": "Step JA Combo",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -106,7 +106,7 @@
 	},
 	{
 		"jp_text": "アーム／砂漠1",
-		"tr_text": "Arm / Caves 1",
+		"tr_text": "Arm / V. Caves 1",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -120,7 +120,7 @@
 	},
 	{
 		"jp_text": "アーム／龍祭壇 1",
-		"tr_text": "Arm / Dragon Altar 1",
+		"tr_text": "Arm / Sanctum 1",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -904,7 +904,7 @@
 	},
 	{
 		"jp_text": "リア／砂漠1",
-		"tr_text": "Rear / Caves 1",
+		"tr_text": "Rear / V. Caves 1",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -918,7 +918,7 @@
 	},
 	{
 		"jp_text": "リア／龍祭壇 1",
-		"tr_text": "Rear / Dragon Altar 1",
+		"tr_text": "Rear / Sanctum 1",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -995,7 +995,7 @@
 	},
 	{
 		"jp_text": "レッグ／砂漠1",
-		"tr_text": "Leg / Caves 1",
+		"tr_text": "Leg / V. Caves 1",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0
@@ -1009,7 +1009,7 @@
 	},
 	{
 		"jp_text": "レッグ／龍祭壇 1",
-		"tr_text": "Leg / Dragon Altar 1",
+		"tr_text": "Leg / Sanctum 1",
 		"jp_explain": "",
 		"tr_explain": "",
 		"assign": 0

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -1305,140 +1305,140 @@
 		"jp_text": "支援デバイス／復活Ｂ",
 		"tr_text": "Support Device/Revival B",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Revival B.\nRevives owner upon incapacitation.\nLow probability.",
+		"tr_explain": "A Mag support function device.\nRevives owner upon incapacitation.\nLow probability.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／無敵Ｂ",
 		"tr_text": "Support Device/Invincibility B",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Invincibility B.\nProvides invincibility when PB fills.\nAverage duration.",
+		"tr_explain": "A Mag support function device.\nProvides invincibility\nwhen PB gauge fills.\nAverage duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／無敵Ｃ",
 		"tr_text": "Support Device/Invincibility C",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Invincibility C.\nProvides invincibility when PB fills.\nLong duration.",
+		"tr_explain": "A Mag support function device.\nProvides invincibility\nwhen PB gauge fills.\nAverage duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／状態異常Ｃ",
 		"tr_text": "Support Device/Status Heal C",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Status Heal C.\nCures status ailments.\nHigh probability, long cooldown.",
+		"tr_explain": "A Mag support function device.\nCures status ailments.\nHigh probability,\nbut long cooldown.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｃ",
 		"tr_text": "Support Device/Stat Boost C",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost C.\nBuffs stats on area change.\nHigh probability, long duration.",
+		"tr_explain": "A Mag support function device.\nBuffs stats on area change.\nHigh probability,\nlong duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｄ",
 		"tr_text": "Support Device/Stat Boost D",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost D.\nBuffs stats when PB fills.\nShort duration.",
+		"tr_explain": "A Mag support function device.\nBuffs stats when PB gauge fills.\nShort duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｆ",
 		"tr_text": "Support Device/Stat Boost F",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost F.\nBuffs stats when PB fills.\nLong duration.",
+		"tr_explain": "A Mag support function device.\nBuffs stats when PB gauge fills.\nLong duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｉ",
 		"tr_text": "Support Device/Stat Boost I",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost I.\nBuffs stats on E-Trial start.\nHigh probability, high cooldown.",
+		"tr_explain": "A Mag support function device.\nBuffs stats when starting\nan Emergency Trial.\nHigh probability, high cooldown.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｊ",
 		"tr_text": "Support Device/Stat Boost J",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost J.\nBuffs stats at fixed intervals.\nLong intervals.",
+		"tr_explain": "A Mag support function device.\nBuffs stats at fixed intervals.\nLong intervals.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｌ",
 		"tr_text": "Support Device/Stat Boost L",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost L.\nBuffs stats at fixed intervals.\nShort intervals.",
+		"tr_explain": "A Mag support function device.\nBuffs stats at fixed intervals.\nShort intervals.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｃ",
 		"tr_text": "Support Device/PP Restore C",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore C.\nBoosts PP regen on area change.\nLow probability, but long duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration on area \nchange. Low probability,\nbut long duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｄ",
 		"tr_text": "Support Device/PP Restore D",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore D.\nBoosts PP regen when PB fills.\nShort duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration when\nPB gauge fills.\nShort duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｅ",
 		"tr_text": "Support Device/PP Restore E",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore E.\nBoosts PP regen when PB fills.\nAverage duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration when\nPB gauge fills.\nAverage duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｆ",
 		"tr_text": "Support Device/PP Restore F",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore F.\nBoosts PP regen when PB fills.\nLong duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration when\nPB gauge fills.\nLong duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｇ",
 		"tr_text": "Support Device/PP Restore G",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore G.\nBoosts PP regen on E-Trial start.\nHigh probability, short duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration when\nstarting an Emergency Trial.\nHigh probability, but short duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｈ",
 		"tr_text": "Support Device/PP Restore H",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore H.\nBoosts PP regen on E-Trial start.\nAverage probability and duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration when\nstarting an Emergency Trial.\nAverage probability, average duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｉ",
 		"tr_text": "Support Device/PP Restore I",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore I.\nBoosts PP regen on E-Trial start.\nLow probability, long duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration when\nstarting an Emergency Trial.\nLow probability, but long duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｊ",
 		"tr_text": "Support Device/PP Restore J",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore J.\nRecovers PP at fixed intervals.\nShort intervals, short duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration at fixed\nintervals.\nShort intervals, short duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｋ",
 		"tr_text": "Support Device/PP Restore K",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore K.\nRecovers PP at fixed intervals.\nAverage intervals, averageduration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration at fixed\nintervals.\nAverage intervals, average duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｌ",
 		"tr_text": "Support Device/PP Restore L",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore L.\nRecovers PP at fixed intervals.\nLong intervals, long duration.",
+		"tr_explain": "A Mag support function device.\nBoosts PP regeneration at fixed\nintervals.\nLong intervals, long duration.",
 		"assign": 0
 	},
 	{
@@ -1452,21 +1452,21 @@
 		"jp_text": "生産デバイス／ＨＰ回復Ｃ",
 		"tr_text": "Support Device/HP Restore C",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / HP Restore C.\nRestores HP when health is low.\nLow probability, high recovery.",
+		"tr_explain": "A Mag support function device.\nRestores HP when health is low.\nLow probability,\nbut high recovery.",
 		"assign": 0
 	},
 	{
 		"jp_text": "生産デバイス／ＨＰ回復Ｊ",
 		"tr_text": "Support Device/HP Restore J",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / HP Restore J.\nRecovers HP at fixed intervals.\nShort intervals, low recovery.",
+		"tr_explain": "A Mag support function device.\nRecovers HP at fixed intervals.\nShort intervals,\nlow recovery.",
 		"assign": 0
 	},
 	{
 		"jp_text": "生産デバイス／ＨＰ回復Ｌ",
 		"tr_text": "Support Device/HP Restore L",
 		"jp_explain": "",
-		"tr_explain": "Mag learns the trigger action:\nSupport / HP Restore L.\nRecovers HP at fixed intervals.\nLong intervals, large recovery.",
+		"tr_explain": "A Mag support function device.\nRecovers HP at fixed intervals.\nAverage intervals,\naverage recovery.",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -1310,140 +1310,140 @@
 	},
 	{
 		"jp_text": "支援デバイス／復活Ｂ",
-		"tr_text": "Support Device / Revival B",
+		"tr_text": "Support Device/Revival B",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Revival B.\nRevives owner upon incapacitation.\nLow probability.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／無敵Ｂ",
-		"tr_text": "Support Device / Invincibility B",
+		"tr_text": "Support Device/Invincibility B",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Invincibility B.\nProvides invincibility when PB fills.\nAverage duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／無敵Ｃ",
-		"tr_text": "Support Device / Invincibility C",
+		"tr_text": "Support Device/Invincibility C",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Invincibility C.\nProvides invincibility when PB fills.\nLong duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／状態異常Ｃ",
-		"tr_text": "Support Device / Status Heal C",
+		"tr_text": "Support Device/Status Heal C",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Status Heal C.\nCures status ailments.\nHigh probability, long cooldown.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｃ",
-		"tr_text": "Support Device / Stat Boost C",
+		"tr_text": "Support Device/Stat Boost C",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost C.\nBuffs stats on area change.\nHigh probability, long duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｄ",
-		"tr_text": "Support Device / Stat Boost D",
+		"tr_text": "Support Device/Stat Boost D",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost D.\nBuffs stats when PB fills.\nShort duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｆ",
-		"tr_text": "Support Device / Stat Boost F",
+		"tr_text": "Support Device/Stat Boost F",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost F.\nBuffs stats when PB fills.\nLong duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｉ",
-		"tr_text": "Support Device / Stat Boost I",
+		"tr_text": "Support Device/Stat Boost I",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost I.\nBuffs stats on E-Trial start.\nHigh probability, high cooldown.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｊ",
-		"tr_text": "Support Device / Stat Boost J",
+		"tr_text": "Support Device/Stat Boost J",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost J.\nBuffs stats at fixed intervals.\nLong intervals.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／能力上昇Ｌ",
-		"tr_text": "Support Device / Stat Boost L",
+		"tr_text": "Support Device/Stat Boost L",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / Stat Boost L.\nBuffs stats at fixed intervals.\nShort intervals.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｃ",
-		"tr_text": "Support Device / PP Restore C",
+		"tr_text": "Support Device/PP Restore C",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore C.\nBoosts PP regen on area change.\nLow probability, but long duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｄ",
-		"tr_text": "Support Device / PP Restore D",
+		"tr_text": "Support Device/PP Restore D",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore D.\nBoosts PP regen when PB fills.\nShort duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｅ",
-		"tr_text": "Support Device / PP Restore E",
+		"tr_text": "Support Device/PP Restore E",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore E.\nBoosts PP regen when PB fills.\nAverage duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｆ",
-		"tr_text": "Support Device / PP Restore F",
+		"tr_text": "Support Device/PP Restore F",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore F.\nBoosts PP regen when PB fills.\nLong duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｇ",
-		"tr_text": "Support Device / PP Restore G",
+		"tr_text": "Support Device/PP Restore G",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore G.\nBoosts PP regen on E-Trial start.\nHigh probability, short duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｈ",
-		"tr_text": "Support Device / PP Restore H",
+		"tr_text": "Support Device/PP Restore H",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore H.\nBoosts PP regen on E-Trial start.\nAverage probability and duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｉ",
-		"tr_text": "Support Device / PP Restore I",
+		"tr_text": "Support Device/PP Restore I",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore I.\nBoosts PP regen on E-Trial start.\nLow probability, long duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｊ",
-		"tr_text": "Support Device / PP Restore J",
+		"tr_text": "Support Device/PP Restore J",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore J.\nRecovers PP at fixed intervals.\nShort intervals, short duration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｋ",
-		"tr_text": "Support Device / PP Restore K",
+		"tr_text": "Support Device/PP Restore K",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore K.\nRecovers PP at fixed intervals.\nAverage intervals, averageduration.",
 		"assign": 0
 	},
 	{
 		"jp_text": "支援デバイス／ＰＰ回復Ｌ",
-		"tr_text": "Support Device / PP Restore L",
+		"tr_text": "Support Device/PP Restore L",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / PP Restore L.\nRecovers PP at fixed intervals.\nLong intervals, long duration.",
 		"assign": 0
@@ -1457,21 +1457,21 @@
 	},
 	{
 		"jp_text": "生産デバイス／ＨＰ回復Ｃ",
-		"tr_text": "Support Device / HP Restore C",
+		"tr_text": "Support Device/HP Restore C",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / HP Restore C.\nRestores HP when health is low.\nLow probability, high recovery.",
 		"assign": 0
 	},
 	{
 		"jp_text": "生産デバイス／ＨＰ回復Ｊ",
-		"tr_text": "Support Device / HP Restore J",
+		"tr_text": "Support Device/HP Restore J",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / HP Restore J.\nRecovers HP at fixed intervals.\nShort intervals, low recovery.",
 		"assign": 0
 	},
 	{
 		"jp_text": "生産デバイス／ＨＰ回復Ｌ",
-		"tr_text": "Support Device / HP Restore L",
+		"tr_text": "Support Device/HP Restore L",
 		"jp_explain": "",
 		"tr_explain": "Mag learns the trigger action:\nSupport / HP Restore L.\nRecovers HP at fixed intervals.\nLong intervals, large recovery.",
 		"assign": 0

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -1165,21 +1165,21 @@
 		"jp_text": "女性Ｃりらボイス",
 		"tr_text": "Female C Lila Voice",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.\nCV: Ai Kayano",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃエリボイス",
 		"tr_text": "Female C Ely Voice",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.\nCV: Asami Imai",
 		"assign": 0
 	},
 	{
 		"jp_text": "女性Ｃクイナボイス",
 		"tr_text": "Female C Quina Voice",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Allows a new voice to be selected.\nUsable by all characters.\nCV: Yui Ogura",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -45,7 +45,7 @@
 		"jp_text": "アタックＰＰリストレイト",
 		"tr_text": "Attack PP Restorate",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Boosts the amount of PP recovered\nwhen hitting with normal attacks.",
 		"assign": 0
 	},
 	{
@@ -136,28 +136,28 @@
 		"jp_text": "ウィークスタンス",
 		"tr_text": "Weak Stance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Active Stance Skill. Increases\ndamage to weak points and tech\ndamage to elemental weaknesses.\nDeactivates Average Stance.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ウィークバレット",
 		"tr_text": "Weak Bullet",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Assault Rifles only. Loads bullets that\nweaken enemies and reduce their\ndefenses.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ウォンドギア",
 		"tr_text": "Wand Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Accumulates gear when hitting\nenemies with charged Techniques,\nand causes normal attacks to\ngenerate a Tech explosion.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ウォンドラバーズ",
 		"tr_text": "Wand Lovers",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "While enabled, Wand Gear stays\nmaxed. Boosts Damage of Tech\nExplosions & Normal Attacks.\nEnables Step Attack.",
 		"assign": 0
 	},
 	{
@@ -185,49 +185,49 @@
 		"jp_text": "エレメンタルバースト",
 		"tr_text": "Elemental Burst",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Unleashes an elemental explosion\nmatching your weapon's attribute.\nMay inflict a status effect.Requires\nJet Boots Gear.",
 		"assign": 0
 	},
 	{
 		"jp_text": "エレメンタルＰＰＲＦ",
 		"tr_text": "Elemental PP Restorate F",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Create a field around yourself that\nrestores PP for attacking enemy\nelemental weaknesses.",
 		"assign": 0
 	},
 	{
 		"jp_text": "エレメントウィークヒット",
 		"tr_text": "Element Weak Hit",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases the damage done to\nelemental weak points.",
 		"assign": 0
 	},
 	{
 		"jp_text": "エレメントコンバージョン",
 		"tr_text": "Element Conversion",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Converts weapon attribute into a\nTechnique damage bonus, higher\nbonus if attributes match.",
 		"assign": 0
 	},
 	{
 		"jp_text": "オールガード",
 		"tr_text": "All Guard",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Blocks damage from all directions\nwhile guarding using Hunter\nweapons.",
 		"assign": 0
 	},
 	{
 		"jp_text": "カタナギア",
 		"tr_text": "Katana Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Boosts S-ATK as gear gauge fills.\nTemporarily boosts S-ATK and critical\nhit rate when you counter with\nmaximum gear.",
 		"assign": 0
 	},
 	{
 		"jp_text": "カタナコンバット",
 		"tr_text": "Katana Combat",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Katanas only. For a fixed time, attack\nand maneuver around nearby\nenemies quickly. Press hotkey again\nfor a finishing attack.",
 		"assign": 0
 	},
 	{
@@ -255,14 +255,14 @@
 		"jp_text": "ガードスタンス",
 		"tr_text": "Guard Stance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Active Stance Skill. Reduces striking\ndamage received, but reduces striking\nand ranged damage dealt.\nDeactivates Fury Stance.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ガードスタンスアドバンス",
 		"tr_text": "Guard Stance Advance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Upon performing a Just Guard during\nGuard Stance, gain a damage bonus\nfor a fixed time.",
 		"assign": 0
 	},
 	{
@@ -290,7 +290,7 @@
 		"jp_text": "コンバットエスケープ",
 		"tr_text": "Combat Escape",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a period of invincibility when\nyou initiate Katana Combat.",
 		"assign": 0
 	},
 	{
@@ -325,14 +325,14 @@
 		"jp_text": "シフタエアアタックブースト",
 		"tr_text": "Shifta Air Attack Boost",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "During Shifta's effect, add a damage\nbonus to air attacks.",
 		"assign": 0
 	},
 	{
 		"jp_text": "シフタストライク",
 		"tr_text": "Shifta Strike",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a damage bonus to Shifta.",
 		"assign": 0
 	},
 	{
@@ -346,7 +346,7 @@
 		"jp_text": "ショウタイム",
 		"tr_text": "Showtime",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "T. Machineguns only. For a fixed time,\ndramatically raises gear accumulation\nin exchange for raising hate\ngeneration.",
 		"assign": 0
 	},
 	{
@@ -360,14 +360,14 @@
 		"jp_text": "ジェットブーツエスケープ",
 		"tr_text": "Jet Boots Escape",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "When using Jet Boots, makes you\ninvincible during PA and normal attack\nShift Actions.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ジェットブーツギア",
 		"tr_text": "Jet Boots Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Fill gear gauge by attacking or\ncharging techs. Adds damage and\nchanges weapon element based on\nlast charged tech.",
 		"assign": 0
 	},
 	{
@@ -381,14 +381,14 @@
 		"jp_text": "スタンディングスナイプ1",
 		"tr_text": "Standing Snipe 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases damage dealt when\nshooting while standing still.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ステップアドバンス",
 		"tr_text": "Step Advance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Extends invincibility during Step.",
 		"assign": 0
 	},
 	{
@@ -444,28 +444,28 @@
 		"jp_text": "ゼロレンジアドバンス1",
 		"tr_text": "Zero Range Advance 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Boosts damage when hitting with\nshots fired at close range.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ソードギア",
 		"tr_text": "Sword Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Depending on the PA, charge\nspeed/number of hits/attack range\nmay change as the gauge fills.",
 		"assign": 0
 	},
 	{
 		"jp_text": "タリステックボーナス",
 		"tr_text": "Talis Tech Bonus",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a power bonus to Techniques\ncast from a thrown talis.",
 		"assign": 0
 	},
 	{
 		"jp_text": "タリスファストスロー",
 		"tr_text": "Talis Fast Throw",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases Talis throw speed.",
 		"assign": 0
 	},
 	{
@@ -479,28 +479,28 @@
 		"jp_text": "ダイブロールアドバンス",
 		"tr_text": "Dive Roll Advance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases invincibility duration during\nDive Roll.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ダイブロールシュート",
 		"tr_text": "Dive Roll Shoot",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Enables attack actions during\nDive Roll.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ダブルセイバーギア",
 		"tr_text": "Double Saber Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Accumulate gear with attacks, then\nuse the weapon action to unleash a\ndamaging wind based on gear level.",
 		"assign": 0
 	},
 	{
 		"jp_text": "チェイスアドバンスプラス",
 		"tr_text": "Chase Advance Plus",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a damage bonus when you\nattack enemies suffering status\nconditions.",
 		"assign": 0
 	},
 	{
@@ -514,49 +514,49 @@
 		"jp_text": "チェイントリガー",
 		"tr_text": "Chain Trigger",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "After invoking the skill, normal attack\nhits will begin a Chain.",
 		"assign": 0
 	},
 	{
 		"jp_text": "チャージエスケープ",
 		"tr_text": "Charge Escape",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Maintain Technique charge during\nMirage Escape.",
 		"assign": 0
 	},
 	{
 		"jp_text": "チャージＰＰリバイバル",
 		"tr_text": "Charge PP Revival",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Recovers PP while charging\nTechniques.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ツインダガーギア",
 		"tr_text": "Twin Dagger Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Accumulates gear based on the\nnumber of jumps, and PA damage\nincreases based on the gear level.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ツインダガースピンムーブ",
 		"tr_text": "Twin Dagger Spin Move",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Allows motion in any direction during\nTwin Daggers' spin.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ツインマシンガンギア",
 		"tr_text": "Twin Machinegun Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Accumulates gear with attacks, and\nincreases the power of attacks.",
 		"assign": 0
 	},
 	{
 		"jp_text": "テックアーツＪＡボーナス",
 		"tr_text": "Tech Arts JA Bonus",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases damage for Just Attacking\nwith different attacks.",
 		"assign": 0
 	},
 	{
@@ -570,21 +570,21 @@
 		"jp_text": "デバンドアタックＰＰＲ",
 		"tr_text": "Deband Attack PP Restorate",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "During Deband's effect, increase PP\nrecovery from normal attacks.",
 		"assign": 0
 	},
 	{
 		"jp_text": "デバンドタフネス",
 		"tr_text": "Deband Toughness",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a maximum HP bonus to\nDeband.",
 		"assign": 0
 	},
 	{
 		"jp_text": "デュアルブレードギア",
 		"tr_text": "Dual Blades Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Gear level boosts PA damage.\nConsume gear to throw Photon\nBlades, boosting PP restoration for\nstruck targets.",
 		"assign": 0
 	},
 	{
@@ -598,35 +598,35 @@
 		"jp_text": "トラップサーチ",
 		"tr_text": "Trap Search",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Allows you to discover hidden traps.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ナックルギア",
 		"tr_text": "Knuckle Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Accumulates gear based on the\nnumber of consecutive attacks, and\nattack speed increases based on the\ngear level.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ナックルギアブースト",
 		"tr_text": "Knuckle Gear Boost",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Doubles Knuckle Gear accumulation\nrate.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ハイタイム",
 		"tr_text": "High Time",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a power bonus during\nShowtime, over time. Resets upon\ntaking a damage in a short time.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ハンターギアブースト",
 		"tr_text": "Hunter Gear Boost",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases gear gauge fill rate for\nHunter weapons during Fury Stance\nor Guard Stance.",
 		"assign": 0
 	},
 	{
@@ -668,14 +668,14 @@
 		"jp_text": "パルチザンギア",
 		"tr_text": "Partizan Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "PAs consume 1 gear gauge when\nused to boost their attack range and\npower.",
 		"assign": 0
 	},
 	{
 		"jp_text": "パーフェクトキーパー",
 		"tr_text": "Perfect Keeper",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases damage to enemies when\nHP is at 75% or higher.",
 		"assign": 0
 	},
 	{
@@ -689,14 +689,14 @@
 		"jp_text": "ファーストヒット",
 		"tr_text": "First Hit",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Grants a damage bonus when you\nattack an enemy which has not lost\nany HP.",
 		"assign": 0
 	},
 	{
 		"jp_text": "フォトンブレードエスケープ",
 		"tr_text": "Photon Blade Escape",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Makes you invincible during\nmovement while using Photon Blades.",
 		"assign": 0
 	},
 	{
@@ -717,14 +717,14 @@
 		"jp_text": "フューリースタンス",
 		"tr_text": "Fury Stance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Passive Stance Skill. Boosts striking\nand ranged damage dealt, but\nincreases striking damage received.",
 		"assign": 0
 	},
 	{
 		"jp_text": "フレイムテックＳチャージ",
 		"tr_text": "Flame Tech S Charge",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Reduces the charge time of Fire\nTechniques.",
 		"assign": 0
 	},
 	{
@@ -808,7 +808,7 @@
 		"jp_text": "ラピッドシュート",
 		"tr_text": "Rapid Shot",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "A Bullet Bow skill. For a limited time,\nsacrifices the bow's normal attack\npower and rate of fire for a three-shot\nnormal attack.",
 		"assign": 0
 	},
 	{
@@ -822,21 +822,21 @@
 		"jp_text": "ラピッドシュートマスタリー",
 		"tr_text": "Rapid Shot Mastery",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "During Rapid Shot, receive a\ndamage bonus for Bullet Bows.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ラピッドブースト",
 		"tr_text": "Rapid Boost",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "For a certain time, increase Jet Boots\nPA charge speed.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ラピッドブーストＪＡボーナス",
 		"tr_text": "Rapid Boost JA Bonus",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Jet Boots only. Grants a\ndamage bonus to Just Attacks\nduring Rapid Boost.",
 		"assign": 0
 	},
 	{
@@ -934,7 +934,7 @@
 		"jp_text": "リミットブレイク",
 		"tr_text": "Limit Break",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "For a fixed time, cut maximum HP to\ngain a bonus to striking damage.",
 		"assign": 0
 	},
 	{
@@ -1025,14 +1025,14 @@
 		"jp_text": "ワイズスタンス",
 		"tr_text": "Wise Stance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Active Stance Skill. Boosts damage\nwhen attacking enemies from the rear.\nDeactivates Brave Stance.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ワイヤードランスギア",
 		"tr_text": "Wired Lance Gear",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Holding PAs consume 1 gear gauge\nto boost their power.",
 		"assign": 0
 	},
 	{
@@ -1284,21 +1284,21 @@
 		"jp_text": "射撃アップ1",
 		"tr_text": "R-ATK Boost 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Boosts R-ATK.",
 		"assign": 0
 	},
 	{
 		"jp_text": "打撃アップ1",
 		"tr_text": "S-ATK Boost 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Boosts S-ATK.",
 		"assign": 0
 	},
 	{
 		"jp_text": "技量アップ1",
 		"tr_text": "DEX Boost 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Boosts DEX.",
 		"assign": 0
 	},
 	{
@@ -1445,7 +1445,7 @@
 		"jp_text": "法撃アップ1",
 		"tr_text": "T-ATK Boost 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases Technique attack.",
 		"assign": 0
 	},
 	{
@@ -2026,7 +2026,7 @@
 		"jp_text": "ＤＳウィンドパリング",
 		"tr_text": "Double Saber Wind Parry",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Allows Just Guard at the moment of\nactivating Double Sabers' tornado.",
 		"assign": 0
 	},
 	{
@@ -2040,42 +2040,42 @@
 		"jp_text": "ＰＰアップ1",
 		"tr_text": "PP Boost 1",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases maximum PP.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ＰＰスレイヤー",
 		"tr_text": "PP Slayer",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases S-ATK, R-ATK, and T-ATK\nwhen PP falls to 50% or less.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ＰＰリストレイト",
 		"tr_text": "PP Restorate",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases the amount of PP\nautomatically restored. PP recovery is\nfurther increased while standing still.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ヒーリングガード",
 		"tr_text": "Healing Guard",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Upon a successful Just Guard,\nrestore HP for yourself and all nearby\ncharacters.",
 		"assign": 0
 	},
 	{
 		"jp_text": "キリングボーナス",
 		"tr_text": "Killing Bonus",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Restores PP when nearby enemies\nare killed.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ヒールシェア",
 		"tr_text": "Heal Share",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "When recovering HP, a portion of\nrecovered HP will be restored for\nnearby players.",
 		"assign": 0
 	},
 	{
@@ -2096,35 +2096,35 @@
 		"jp_text": "Ｔマシンガンマスタリー",
 		"tr_text": "Twin Machinegun Mastery",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases PP regeneration and\ncritical hit damage while using\nTwin Machineguns.",
 		"assign": 0
 	},
 	{
 		"jp_text": "クイックメイト",
 		"tr_text": "Quick Mate",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increases speed of using -mate items.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ボルトテックＰＰセイブ",
 		"tr_text": "Bolt Tech PP Save",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Reduce the PP cost of Lightning\nTechniques.",
 		"assign": 0
 	},
 	{
 		"jp_text": "アタックアドバンス",
 		"tr_text": "Attack Advance",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "Increase damage for normal attacks.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ステップJAコンボ",
 		"tr_text": "Step JA Combo",
 		"jp_explain": "",
-		"tr_explain": "",
+		"tr_explain": "JA again after performing a Step\naction.",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -10,7 +10,7 @@
 		"jp_text": "ゆる三つ編み前",
 		"tr_text": "Front Loose Braid",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Front Loose Braid\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Unlocks the hairstyle\n\"Front Loose Braid\"\nfor use in the Beauty Salon.",
 		"assign": 0
 	},
 	{
@@ -136,7 +136,7 @@
 		"jp_text": "ウィザードぺタソス",
 		"tr_text": "Wizard's Petasos (Duplicate)",
 		"jp_explain": "",
-		"tr_explain": "By using this ticket, the hairstyle\n\"Wizard's Petasos\"\ncan be used in the Beauty Salon.",
+		"tr_explain": "Unlocks the hairstyle\n\"Wizard's Petasos\"\nfor use in the Beauty Salon.",
 		"assign": 0
 	},
 	{

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -11147,7 +11147,7 @@
 	{
 		"assign": "friend_pso2_button",
 		"jp_text": "PSO2フレンド",
-		"tr_text": "PSO2 Friends"
+		"tr_text": "PSO2 friends"
 	},
 	{
 		"assign": "friend_list_button",
@@ -11157,7 +11157,7 @@
 	{
 		"assign": "friend_search_button",
 		"jp_text": "フレンド検索",
-		"tr_text": "Search Friends"
+		"tr_text": "Search friends"
 	},
 	{
 		"assign": "friend_login_1",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -2907,7 +2907,7 @@
 	{
 		"assign": "menu_dialog_t_23",
 		"jp_text": "タイトルへ戻る",
-		"tr_text": "Back to title"
+		"tr_text": "Back to Title"
 	},
 	{
 		"assign": "menu_dialog_b_23",
@@ -7467,7 +7467,7 @@
 	{
 		"assign": "title_dialog08_button_new",
 		"jp_text": "タイトルへ戻る",
-		"tr_text": "Back to title"
+		"tr_text": "Back to Title"
 	},
 	{
 		"assign": "title_dialog_t_11",
@@ -10322,7 +10322,7 @@
 	{
 		"assign": "menu_sub_button_title",
 		"jp_text": "タイトルへ戻る",
-		"tr_text": "Back to title"
+		"tr_text": "Back to Title"
 	},
 	{
 		"assign": "menu_sub_button_ship",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -11147,7 +11147,7 @@
 	{
 		"assign": "friend_pso2_button",
 		"jp_text": "PSO2フレンド",
-		"tr_text": "PSO2 friends"
+		"tr_text": "PSO2 Friends"
 	},
 	{
 		"assign": "friend_list_button",
@@ -11157,7 +11157,7 @@
 	{
 		"assign": "friend_search_button",
 		"jp_text": "フレンド検索",
-		"tr_text": "Search friends"
+		"tr_text": "Search Friends"
 	},
 	{
 		"assign": "friend_login_1",


### PR DESCRIPTION
-Fix skill ring names and descriptions
-Fix mag function devices
-Translate championship room items
-Fix scape doll names and descriptions
-Fix the names and descriptions of items in leftovers and clear invalid or already covered entries
-Add class skill disks to leftovers
Append
-Fix Stealth Weapon names and descriptions
-Fix mag function device description
-Add class skill disk descriptions
-Fix Battle Arena related weapon names, descriptions and potentials
-Fix some TMG names
-Fix some pso2es button capitalization