### PR TITLE
pso2es EN: Various fixes

### DIFF
--- a/json/ChipExplain_ActiveExplain.txt
+++ b/json/ChipExplain_ActiveExplain.txt
@@ -228,14 +228,14 @@
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30002",
 		"jp_explainShort": "通常攻撃と移動を加速＋攻撃力を大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30003",
@@ -270,14 +270,14 @@
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 120.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 130.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 120.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 130.\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "30008",
 		"jp_explainShort": "通常攻撃と移動を加速＋弱点属性を劇的強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 140.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 150.\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 140.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 150.\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "30013",
@@ -368,14 +368,14 @@
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 500.\n②  Gives Normal Attacks a chance to inflict [Panic].\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30034",
 		"jp_explainShort": "通常攻撃に「パニック」＋攻撃力を大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「パニック」効果を付与する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Gives normal attacks a chance to inflict [Panic].\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Gives Normal Attacks a chance to inflict [Panic].\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "1690",
@@ -956,14 +956,14 @@
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n②  Deals an additional 10% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7000)\n②  Deals an additional 10% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31250",
 		"jp_explainShort": "攻撃３回ごと攻撃力大強化＋追加小ダメージ",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：絶大）\n② 敵に追加で小ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n②  Deals an additional 20% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 25% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7000)\n②  Deals an additional 20% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 25% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31255",
@@ -1040,28 +1040,28 @@
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 9000)\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Increases your ATK by 800 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 8000)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 9000)\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31312",
 		"jp_explainShort": "攻撃３回毎に攻撃力劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 自身の通常攻撃と移動スピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 1000 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 10000)\n<color=yellow>SP: </color>Increases your ATK by 1100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 11000)\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases your ATK by 1000 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 10000)\n<color=yellow>SP: </color>Increases your ATK by 1100 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 11000)\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31315",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 30% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 6000)\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Boosts damage by 30% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 31% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 6000)\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31316",
 		"jp_explainShort": "雷枚数攻撃絶大増＋攻撃３回毎攻撃劇的強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の雷属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 33% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 6000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Boosts damage by 33% x the number of Lightning\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 35% x the number of Lightning\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 800 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 6000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31319",
@@ -1166,14 +1166,14 @@
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Boosts damage by 200%.\n<color=yellow>SP: </color>Boosts damage by 210%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31390",
 		"jp_explainShort": "攻撃増＋加速＋ボス時氷チップ数で攻撃増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ ボス戦時は装備中の氷属性チップの枚数に応じて\n　　 さらに攻撃力を大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Boosts damage by 220%.\n<color=yellow>SP: </color>Boosts damage by 230%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n③  Boosts damage against bosses by 10% x the\n     number of Ice chips equipped.\n     <color=yellow>[E-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31405",
@@ -1194,14 +1194,14 @@
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31410",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31417",
@@ -1236,14 +1236,14 @@
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31426",
 		"jp_explainShort": "「バーン」付与＋「バーン」時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 「バーン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 90% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Burn].\n②  Boosts damage by 90% against enemies affected\n     by [Burn].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31427",
@@ -1334,14 +1334,14 @@
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 20% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 21% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 1000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Boosts damage by 20% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 21% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 1000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31484",
 		"jp_explainShort": "風枚数攻撃絶大増＋攻撃３回毎攻撃小強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の風属性チップの枚数に応じて\n　　 攻撃力を絶大に増加する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 22% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 23% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 1000)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Boosts damage by 22% x the number of Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts damage by 23% x the number of Wind\n     chips equipped.\n     <color=yellow>[E-Frame]</color>\n②  Increases your ATK by 125 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 1000)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31485",
@@ -1390,14 +1390,14 @@
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 60% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 60% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31510",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31517",
@@ -1446,14 +1446,14 @@
 		"jp_explainShort": "ミラージュ付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31534",
 		"jp_explainShort": "ミラージュ付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31539",
@@ -1551,14 +1551,14 @@
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋特大追撃",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 8000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31582",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋特大追撃",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加で特大ダメージを与える。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 850 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8500)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 9000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Increases your ATK by 850 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 8500)\n<color=yellow>SP: </color>Increases your ATK by 900 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 9000)\n②  Deals an additional 70% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31589",
@@ -1747,14 +1747,14 @@
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対してダメージを増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 35% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 40% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n②  Boosts damage by 35% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 40% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 50 seconds"
 	},
 	{
 		"assign": "31674",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を与える。\n② 「ポイズン」状態の敵に対してダメージを大きく増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 45% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 50% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n②  Boosts damage by 45% against enemies affected\n     by [Poison].\n<color=yellow>SP: </color>Boosts damage by 50% against enemies affected\n     by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31677",
@@ -1789,21 +1789,21 @@
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from Normal Attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31703",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は闇属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from Normal Attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Dark PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31704",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from Normal Attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31711",
@@ -2454,14 +2454,14 @@
 		"jp_explainShort": "ダメージ効果超絶増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to evade damage from\n     enemies.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to evade damage from\n     enemies.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31981",
 		"jp_explainShort": "ダメージ効果超絶増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to evade damage from\n     enemies.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 30% chance to evade damage from\n     enemies.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "31992",
@@ -2503,28 +2503,28 @@
 		"jp_explainShort": "ヤスミノコフ8000C[水着]",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を超絶に強化する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts attack power by 230% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 240% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Boosts attack power by 230% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 240% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "32002",
 		"jp_explainShort": "ヤスミノコフ8000C[Ｓ水着]",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中のウェポノイドチップの枚数に応じ\n　　 攻撃の威力を極度に強化する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts attack power by 250% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 260% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Boosts attack power by 250% + 10% x the\n     number of Weaponoid chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 260% + 10% x the\n     number of Weaponoid chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "32009",
 		"jp_explainShort": "ギレスヴァイエン",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 8000.\n<color=yellow>SP: </color>Increases your ATK by 9000.\n②  Increases your ATK by 1400 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases your ATK by 8000.\n<color=yellow>SP: </color>Increases your ATK by 9000.\n②  Increases your ATK by 1400 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7000)\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "32010",
 		"jp_explainShort": "ギレスヴァイエン（解放後）",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 10000.\n<color=yellow>SP: </color>Increases your ATK by 11000.\n②  Increases your ATK by 1400 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Increases your ATK by 10000.\n<color=yellow>SP: </color>Increases your ATK by 11000.\n②  Increases your ATK by 1400 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7000)\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "32011",
@@ -2643,14 +2643,14 @@
 		"jp_explainShort": "攻撃力増加＋状態異常無効",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 攻撃対象の敵からダメージを受けた時\n　　 一定確率でランダムな状態異常効果を付与する。\n③ 状態異常の敵に対してダメージを絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 130% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 135% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 130% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 135% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "32046",
 		"jp_explainShort": "攻撃力大増加＋状態異常無効",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 攻撃対象の敵からダメージを受けた時\n　　 一定確率でランダムな状態異常効果を付与する。\n③ 状態異常の敵に対してダメージを絶大に増加する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 140% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 145% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 140% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 145% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "32052",
@@ -2993,14 +2993,14 @@
 		"jp_explainShort": "対象を高速回転させる自在槍用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で超絶ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 250% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 260% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by ??%.\n③  Recovers 5 CP every 4.9 seconds.\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Deals an additional 250% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 260% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by ??%.\n③  Recovers 5 CP every 4.9 seconds.\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "32189",
 		"jp_explainShort": "対象を高速回転させる自在槍用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で超絶ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n③ 定期的にＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Deals an additional 270% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 280% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by ??%.\n③  Recovers 5 CP every 4.9 seconds.\n[Effect Duration] 70 seconds"
+		"tr_explainLong": "①  Deals an additional 270% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 280% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by ??%.\n③  Recovers 5 CP every 4.9 seconds.\n[Effect Duration] 70 seconds"
 	},
 	{
 		"assign": "32194",
@@ -3329,14 +3329,14 @@
 		"jp_explainShort": "身体を振り連続攻撃する鋼拳用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ アクティブチップ使用か通常攻撃を３回行うごとに\n　　 ＨＰまたはＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Recovers HP by ?% or recovers ? CP every 3\n     times you use an active chip or a normal attack.\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Recovers HP by ?% or recovers ? CP every 3\n     times you use an active chip or a Normal Attack.\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32357",
 		"jp_explainShort": "身体を振り連続攻撃する鋼拳用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ アクティブチップ使用か通常攻撃を３回行うごとに\n　　 ＨＰまたはＣＰをわずかに回復する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 280%.\n<color=yellow>SP: </color>Boosts damage effects by 290%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Recovers HP by ?% or recovers ? CP every 3\n     times you use an active chip or a normal attack.\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by 280%.\n<color=yellow>SP: </color>Boosts damage effects by 290%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Recovers HP by ?% or recovers ? CP every 3\n     times you use an active chip or a Normal Attack.\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32370",
@@ -3378,14 +3378,14 @@
 		"jp_explainShort": "身体を振り連続攻撃する鋼拳用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 220%.\n<color=yellow>SP: </color>Boosts damage effects by 230%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by 220%.\n<color=yellow>SP: </color>Boosts damage effects by 230%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32396",
 		"jp_explainShort": "身体を振り連続攻撃する鋼拳用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32397",
@@ -3987,14 +3987,14 @@
 		"jp_explainShort": "矢の雨を降り注がせる強弓用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 通常攻撃に「バーン」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 420.\n<color=yellow>SP: </color>Increases your ATK by 440.\n②  Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your ATK by 420.\n<color=yellow>SP: </color>Increases your ATK by 440.\n②  Gives Normal Attacks a chance to inflict [Burn].\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "80820",
 		"jp_explainShort": "矢の雨を降り注がせる強弓用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「バーン」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Gives normal attacks a chance to inflict [Burn].\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Increases your ATK by 450.\n<color=yellow>SP: </color>Increases your ATK by 470.\n②  Gives Normal Attacks a chance to inflict [Burn].\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "80910",
@@ -4057,14 +4057,14 @@
 		"jp_explainShort": "矢の雨を降り注がせる強弓用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を強化する。\n② 通常攻撃に「ミラージュ」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 430.\n<color=yellow>SP: </color>Increases your ATK by 450.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your ATK by 430.\n<color=yellow>SP: </color>Increases your ATK by 450.\n②  Gives Normal Attacks a chance to inflict [Mirage].\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "81620",
 		"jp_explainShort": "矢の雨を降り注がせる強弓用の必殺技",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を付与する。\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 480.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 480.\n②  Gives Normal Attacks a chance to inflict [Mirage].\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "81710",
@@ -9727,14 +9727,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 法術の威力をわずかに強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 15%.\n<color=yellow>SP: </color>Boosts the power of Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 15%.\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts the power of Techs by 15%.\n<color=yellow>SP: </color>Boosts the power of Techs by 20%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 15%.\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "20044",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 法術の威力をわずかに強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of Techs by 25%.\n<color=yellow>SP: </color>Boosts the power of Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 15%.\n[Effect Duration] 40 seconds"
+		"tr_explainLong": "①  Boosts the power of Techs by 25%.\n<color=yellow>SP: </color>Boosts the power of Techs by 30%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 15%.\n[Effect Duration] 40 seconds"
 	},
 	{
 		"assign": "5410",

--- a/json/ChipExplain_SupportExplain.txt
+++ b/json/ChipExplain_SupportExplain.txt
@@ -256,14 +256,14 @@
 		"jp_explainShort": "通常攻撃に「フリーズ」効果＋攻撃大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「フリーズ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives Normal Attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30040",
 		"jp_explainShort": "通常攻撃に「フリーズ」効果＋攻撃大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「フリーズ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives Normal Attacks a chance to inflict [Freeze].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30041",
@@ -368,28 +368,28 @@
 		"jp_explainShort": "通常攻撃に「ポイズン」効果＋攻撃大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ポイズン」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives Normal Attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30062",
 		"jp_explainShort": "通常攻撃に「ポイズン」効果＋攻撃大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ポイズン」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives Normal Attacks a chance to inflict [Poison].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30063",
 		"jp_explainShort": "通常攻撃に「ミラージュ」効果＋攻撃大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Increases your ATK by 460.\n<color=yellow>SP: </color>Increases your ATK by 520.\n②  Gives Normal Attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "30064",
 		"jp_explainShort": "通常攻撃に「ミラージュ」効果＋攻撃大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 通常攻撃に「ミラージュ」効果を与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives normal attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 580.\n<color=yellow>SP: </color>Increases your ATK by 640.\n②  Gives Normal Attacks a chance to inflict [Mirage].\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30065",
@@ -410,14 +410,14 @@
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Speeds up movement and normal attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 550.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Speeds up movement and Normal Attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "30070",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n②  Speeds up movement and normal attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your ATK by 650.\n<color=yellow>SP: </color>Increases your ATK by 700.\n②  Speeds up movement and Normal Attacks by 20%.\n[Activation Trigger] Slide Action\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "30073",
@@ -634,28 +634,28 @@
 		"jp_explainShort": "攻撃力大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your ATK by 500.\n<color=yellow>SP: </color>Increases your ATK by 600.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31016",
 		"jp_explainShort": "攻撃力劇的強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 800.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your ATK by 700.\n<color=yellow>SP: </color>Increases your ATK by 800.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31017",
 		"jp_explainShort": "雷属性大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 60.\n<color=yellow>SP: </color>Increases your Lightning Element by 66.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your Lightning Element by 60.\n<color=yellow>SP: </color>Increases your Lightning Element by 66.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31018",
 		"jp_explainShort": "雷属性大強化＋攻撃３回ごと攻撃力小強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 雷属性を大きく強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "①  Increases your Lightning Element by 70.\n<color=yellow>SP: </color>Increases your Lightning Element by 84.\n②  Increases your ATK by 150 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 4000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31019",
@@ -676,14 +676,14 @@
 		"jp_explainShort": "通常攻撃と移動が加速＋風属性が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 風属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Wind Element by 70.\n<color=yellow>SP: </color>Increases your Wind Element by 77.\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your Wind Element by 70.\n<color=yellow>SP: </color>Increases your Wind Element by 77.\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31022",
 		"jp_explainShort": "通常攻撃と移動が加速＋風属性が劇的強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 風属性を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Wind Element by 80.\n<color=yellow>SP: </color>Increases your Wind Element by 96.\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your Wind Element by 80.\n<color=yellow>SP: </color>Increases your Wind Element by 96.\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31023",
@@ -1222,14 +1222,14 @@
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 120% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 120% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31134",
 		"jp_explainShort": "状態異常付与＋状態異常ダメージ絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 160% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 180% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 160% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 180% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31135",
@@ -1264,14 +1264,14 @@
 		"jp_explainShort": "炎属性強化＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 炎属性を強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 25.\n②  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases your Fire Element by 20.\n<color=yellow>SP: </color>Increases your Fire Element by 25.\n②  Increases your ATK by 500 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31144",
 		"jp_explainShort": "炎属性強化＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 炎属性を強化する。\n② アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your Fire Element by 30.\n<color=yellow>SP: </color>Increases your Fire Element by 35.\n②  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your Fire Element by 30.\n<color=yellow>SP: </color>Increases your Fire Element by 35.\n②  Increases your ATK by 500 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 5000)\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31147",
@@ -1460,14 +1460,14 @@
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 50% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 60% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Mirage].\n②  Boosts damage by 50% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 60% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31188",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Mirage].\n②  Boosts damage by 70% against enemies\n     affected by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31191",
@@ -1586,14 +1586,14 @@
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 130%.\n<color=yellow>SP: </color>Boosts damage by 150%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31218",
 		"jp_explainShort": "通常攻撃と移動が加速＋攻撃力絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を絶大に増加する。\n②  自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage by 170%.\n<color=yellow>SP: </color>Boosts damage by 190%.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31219",
@@ -1684,42 +1684,42 @@
 		"jp_explainShort": "通常攻撃にバーン付与＋攻撃力劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃時に「バーン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts damage by 80%.\n<color=yellow>SP: </color>Boosts damage by 90%.\n     <color=yellow>[E-Frame]</color>\n②  Gives Normal Attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31234",
 		"jp_explainShort": "通常攻撃にバーン付与＋攻撃力劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃時に「バーン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Gives normal attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 100%.\n<color=yellow>SP: </color>Boosts damage by 110%.\n     <color=yellow>[E-Frame]</color>\n②  Gives Normal Attacks a chance to inflict [Burn].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31235",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n②  Boosts damage by 70% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Panic].\n②  Boosts damage by 70% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31236",
 		"jp_explainShort": "パニック付与＋パニック時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n② 「パニック」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n②  Boosts damage by 90% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Panic].\n②  Boosts damage by 90% against enemies affected\n     by [Panic].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies affected\n     by [Panic].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31237",
 		"jp_explainShort": "攻撃力劇的増加＋通常攻撃で攻撃力微増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃を行うたびに\n　　 さらに攻撃力をわずかに増加する。（最大時：劇的）\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a normal attack.\n     (Maximum additional boost: 30%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a Normal Attack.\n     (Maximum additional boost: 30%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31238",
 		"jp_explainShort": "攻撃力劇的増加＋通常攻撃で攻撃力微増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃を行うたびに\n　　 さらに攻撃力をわずかに増加する。（最大時：絶大）\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a normal attack.\n     (Maximum additional boost: 30%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts damage by a further 5% each time you\n     perform a Normal Attack.\n     (Maximum additional boost: 30%)\n     <color=yellow>[E-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31239",
@@ -1838,14 +1838,14 @@
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 16% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 16% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 17% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31276",
 		"jp_explainShort": "通常攻撃と移動加速＋炎チップ数攻撃劇的増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の炎属性チップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage by 19% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage by 19% x the number of Fire chips\n     equipped.\n<color=yellow>SP: </color>Boosts damage by 20% x the number of Fire chips\n     equipped.\n     <color=yellow>[E-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31279",
@@ -1866,14 +1866,14 @@
 		"jp_explainShort": "通常攻撃にポイズン付与＋弱点属性大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を大きく強化する。\n② 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 70.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 60.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 70.\n②  Gives Normal Attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31282",
 		"jp_explainShort": "通常攻撃にポイズン付与＋弱点属性劇的強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃対象の敵の弱点属性を劇的に強化する。\n② 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 80.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 90.\n②  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Increases all Elements that the target is weak\n     to by 80.\n<color=yellow>SP: </color>Increases all Elements that the target is weak\n     to by 90.\n②  Gives Normal Attacks a chance to inflict [Poison].\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31283",
@@ -2174,14 +2174,14 @@
 		"jp_explainShort": "必殺技大強化＋通常攻撃と移動加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技の威力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts the power of PAs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31348",
 		"jp_explainShort": "必殺技劇的強化＋通常攻撃と移動加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts the power of PAs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts the power of PAs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31349",
@@ -2398,14 +2398,14 @@
 		"jp_explainShort": "バーン付与＋バーン時ダメージ絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 120% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Burn].\n②  Boosts damage by 120% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 140% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31384",
 		"jp_explainShort": "バーン付与＋バーン時ダメージ絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を付与する。\n② 「バーン」状態の敵に対して\n　　 ダメージを絶大に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 160% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 180% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Burn].\n②  Boosts damage by 160% against enemies\n     affected by [Burn].\n<color=yellow>SP: </color>Boosts damage by 180% against enemies\n     affected by [Burn].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31385",
@@ -2468,42 +2468,42 @@
 		"jp_explainShort": "強弓の技が劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 強弓の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31396",
 		"jp_explainShort": "強弓の技が劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 強弓の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts the power of Bullet Bow PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Bullet Bow PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31397",
 		"jp_explainShort": "抜剣の技が劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 抜剣の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 85%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 90%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31398",
 		"jp_explainShort": "抜剣の技が劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 抜剣の必殺技の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts the power of Gunslash PAs by 95%.\n<color=yellow>SP: </color>Boosts the power of Gunslash PAs by 100%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31399",
 		"jp_explainShort": "追加大ダメージ＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 3000\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 3000\n②  Deals an additional 40% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 45% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31400",
 		"jp_explainShort": "追加大ダメージ＋攻撃３回ごと攻撃力大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を大きく強化する。（最大時：劇的）\n② 敵に追加で大ダメージを与える。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 3000)\n②  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
+		"tr_explainLong": "①  Increases your ATK by 500 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 3000)\n②  Deals an additional 50% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 55% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 35 seconds"
 	},
 	{
 		"assign": "31401",
@@ -2608,14 +2608,14 @@
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ大増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを大きく増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 60% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Mirage].\n②  Boosts damage by 60% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31424",
 		"jp_explainShort": "ミラージュ付与＋ミラージュ時ダメージ劇的増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ミラージュ」効果を付与する。\n② 「ミラージュ」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Mirage].\n②  Boosts damage by 80% against enemies affected\n     by [Mirage].\n<color=yellow>SP: </color>Boosts damage by 90% against enemies affected\n     by [Mirage].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31429",
@@ -2804,14 +2804,14 @@
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 70% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n②  Boosts damage by 70% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 80% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31464",
 		"jp_explainShort": "ポイズン付与＋ポイズン時ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n② 「ポイズン」状態の敵に対して\n　　 ダメージを劇的に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Boosts damage by 90% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n②  Boosts damage by 90% against enemies\n     affected by [Poison].\n<color=yellow>SP: </color>Boosts damage by 100% against enemies\n     affected by [Poison].\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31465",
@@ -2846,14 +2846,14 @@
 		"jp_explainShort": "攻撃劇的増加＋常時ジャストアタック",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "①  Boosts damage by 70%.\n<color=yellow>SP: </color>Boosts damage by 80%.\n     <color=yellow>[E-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "31470",
 		"jp_explainShort": "攻撃劇的増加＋常時ジャストアタック",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を劇的に増加する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Boosts damage by 90%.\n<color=yellow>SP: </color>Boosts damage by 100%.\n     <color=yellow>[E-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31471",
@@ -3224,14 +3224,14 @@
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Deals an additional 100% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 110% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31548",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Deals an additional 120% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 130% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31549",
@@ -3329,14 +3329,14 @@
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage up to\n     5% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a shield that prevents damage up to\n     6% x the number of different chip elements\n     equipped.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Boosts damage by 40%.\n<color=yellow>SP: </color>Boosts damage by 50%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage up to\n     5% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a shield that prevents damage up to\n     6% x the number of different chip elements\n     equipped.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31565",
 		"jp_explainShort": "攻撃力大増加＋ダメージ防御＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を大きく増加する。\n② 装備中の属性種類数に応じて\n　　 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功もしくはスライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage up to\n     7% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a shield that prevents damage up to\n     8% x the number of different chip elements\n     equipped.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts damage by 60%.\n<color=yellow>SP: </color>Boosts damage by 70%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage up to\n     7% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Grants you a shield that prevents damage up to\n     8% x the number of different chip elements\n     equipped.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful JA or Slide Action\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31568",
@@ -3399,14 +3399,14 @@
 		"jp_explainShort": "バーン付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Burn].\n②  Boosts damage by 70% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 75% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31584",
 		"jp_explainShort": "バーン付与＋状態異常ダメージ劇的増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「バーン」効果を与える。\n② 状態異常の敵に対してダメージを劇的に増加する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Burn].\n②  Boosts damage by 80% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Burn].\n②  Boosts damage by 80% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 85% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31585",
@@ -3427,14 +3427,14 @@
 		"jp_explainShort": "絶大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 145% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 155% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Deals an additional 145% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 155% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31588",
 		"jp_explainShort": "絶大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 175% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Deals an additional 165% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 175% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31591",
@@ -3931,21 +3931,21 @@
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 200% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 205% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all Link Slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 200% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 205% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all Link Slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31690",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は雷属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 215% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 220% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all Link Slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 215% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 220% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all Link Slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Lightning PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31691",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋属性ダメージ",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃と必殺技にランダムで\n　　 特定の状態異常を付与する。\n② 状態異常の敵に対してダメージを超絶に増加する。\n③ 全てのリンクスロットに装備した雷属性チップの数に応じ\n　　 雷属性が弱点の敵に対して\n　　 その属性によるダメージを大きく増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 230% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 235% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all Link Slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks and PAs a chance to inflict\n     random status effects.\n②  Boosts damage by 230% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 235% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Boosts Lightning elemental damage against\n     enemies weak to Lightning by 7% x the number\n     of Lightning chips in all Link Slots.\n     <color=yellow>[S-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31692",
@@ -4036,28 +4036,28 @@
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 35% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Deals an additional 35% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31710",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中チップの属性種類数に応じて\n　　 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 45% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Deals an additional 45% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n<color=yellow>SP: </color>Deals an additional 50% damage to enemies +\n     10% x the number of different chip elements\n     equipped.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31715",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋大軽減",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n③ 状態異常の敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 65% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 65% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 70% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31716",
 		"jp_explainShort": "状態異常付与＋状態異常特攻＋大軽減",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを劇的に増加する。\n③ 状態異常の敵から受けるダメージを大きく軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 75% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 75% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 80% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n③  Reduces damage taken from enemies affected by\n     status effects by 40%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31717",
@@ -4078,14 +4078,14 @@
 		"jp_explainShort": "大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31720",
 		"jp_explainShort": "特大追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31721",
@@ -4463,21 +4463,21 @@
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 250%.\n<color=yellow>SP: </color>Boosts damage by 255%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from Normal Attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31805",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は風属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 265%.\n<color=yellow>SP: </color>Boosts damage by 270%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from Normal Attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     Wind PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31806",
 		"jp_explainShort": "攻撃力増＋ＣＰ回復量増＋属性一致攻撃力増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力を超絶に増加する。\n② 通常攻撃によるＣＰの回復量を大きく増加する。\n③ 装備中の武器の属性がリンクスロットに装備した\n　　 チップの属性と一致する場合、攻撃力を増加する。\n④ このチップを装備中は全属性の必殺技・法術の\n　　 チップコストが減少する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from normal attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage by 290%.\n<color=yellow>SP: </color>Boosts damage by 295%.\n     <color=yellow>[E-Frame]</color>\n②  Boosts CP recovery from Normal Attacks by 80%.\n③  Boosts damage by 30% if the equipped weapon's\n     element matches the element of the chip in this\n     chip's Link Slot.\n     <color=yellow>[H-Frame]</color>\n④  While this chip is equipped, the equip costs of\n     all PAs and Techs are halved.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31807",
@@ -4512,14 +4512,14 @@
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋追撃",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：絶大）\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 700 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7000)\n<color=yellow>SP: </color>Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n②  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases your ATK by 700 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7000)\n<color=yellow>SP: </color>Increases your ATK by 750 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7500)\n②  Deals an additional 30% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 35% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31812",
 		"jp_explainShort": "攻撃３回毎攻撃力劇的強化＋追撃",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力を劇的に強化する。（最大時：超絶）\n② 敵に追加でダメージを与える。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 8000)\n②  Deals an additional 35% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
+		"tr_explainLong": "①  Increases your ATK by 750 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 7500)\n<color=yellow>SP: </color>Increases your ATK by 800 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 8000)\n②  Deals an additional 35% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 40% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 60 seconds"
 	},
 	{
 		"assign": "31813",
@@ -4631,28 +4631,28 @@
 		"jp_explainShort": "光枚数超絶追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 敵に追加で超絶ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 205% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 210% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Deals an additional 205% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 210% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31833",
 		"jp_explainShort": "光枚数超絶追撃＋常時ジャストアタック＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の光属性チップの枚数に応じて\n　　 敵に追加で超絶ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 215% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 220% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Deals an additional 215% damage to enemies +\n     10% x the number of Light chips equipped.\n<color=yellow>SP: </color>Deals an additional 220% damage to enemies +\n     10% x the number of Light chips equipped.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31836",
 		"jp_explainShort": "技法威力絶大強化＋弱属武器攻撃力大増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合、攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 130%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 130%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 135%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31837",
 		"jp_explainShort": "技法威力絶大強化＋弱属武器攻撃力大増",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が攻撃対象の敵の弱点に\n　　 有効な属性の場合、攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 140%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 145%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 140%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 145%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by 50% if the equipped weapon's\n     element matches the target's elemental\n     weakness.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31838",
@@ -4848,14 +4848,14 @@
 		"jp_explainShort": "ダメージ効果絶大増＋ＪＡ成功毎さらに増加＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31890",
 		"jp_explainShort": "ダメージ効果絶大増＋ＪＡ成功毎さらに増加＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31891",
@@ -4876,14 +4876,14 @@
 		"jp_explainShort": "必殺技・法術の威力大強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術の威力を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 55%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 65%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31894",
 		"jp_explainShort": "必殺技・法術の威力劇的強化＋加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術の威力を劇的に強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts the power of PAs and Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts the power of PAs and Techs by 75%.\n<color=yellow>SP: </color>Boosts the power of PAs and Techs by 85%.\n     <color=yellow>[A-Frame]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31895",
@@ -5177,14 +5177,14 @@
 		"jp_explainShort": "ダメージ効果絶大増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 120%.\n<color=yellow>SP: </color>Boosts damage effects by 125%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31956",
 		"jp_explainShort": "ダメージ効果絶大増＋攻撃毎にさらに増加＋回避",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 130%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "31957",
@@ -5275,14 +5275,14 @@
 		"jp_explainShort": "状態異常付与＋状態異常時ダメージ絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 120% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 120% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 125% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "31983",
 		"jp_explainShort": "状態異常付与＋状態異常時ダメージ絶大増加",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 状態異常の敵に対してダメージを絶大に増加する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 130% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 135% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Boosts damage by 130% against enemies affected\n     by status effects.\n<color=yellow>SP: </color>Boosts damage by 135% against enemies affected\n     by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31984",
@@ -5317,14 +5317,14 @@
 		"jp_explainShort": "追加大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Deals an additional 60% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 65% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "31989",
 		"jp_explainShort": "追加特大ダメージ＋通常攻撃と移動が加速",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Deals an additional 70% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 75% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "31990",
@@ -5562,14 +5562,14 @@
 		"jp_explainShort": "ＣＰが大回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中のキャラクターチップの枚数に応じ\n　　 攻撃の威力を極度に強化する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack power by 295% + 5% for each\n     character chip equipped.\n<color=yellow>SP: </color>Boosts attack power by 300% + 5% for each\n     character chip equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts attack power by 295% + 5% for each\n     character chip equipped.\n<color=yellow>SP: </color>Boosts attack power by 300% + 5% for each\n     character chip equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "32051",
 		"jp_explainShort": "定期的にＨＰが小回復＋大剣の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中のキャラクターチップの枚数に応じ\n　　 攻撃の威力を極度に強化する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts attack power by 305% + 5% for each\n     character chip equipped.\n<color=yellow>SP: </color>Boosts attack power by 310% + 5% for each\n     character chip equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts attack power by 305% + 5% for each\n     character chip equipped.\n<color=yellow>SP: </color>Boosts attack power by 310% + 5% for each\n     character chip equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "32054",
@@ -5716,14 +5716,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋抜剣の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を劇的に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 85%.\n<color=yellow>SP: </color>Boosts damage effects by 90%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 85%.\n<color=yellow>SP: </color>Boosts damage effects by 90%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "32093",
 		"jp_explainShort": "定期的にＨＰが小回復＋強弓の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を劇的に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 敵からの攻撃を一定確率で回避する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 95%.\n<color=yellow>SP: </color>Boosts damage effects by 100%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 95%.\n<color=yellow>SP: </color>Boosts damage effects by 100%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Grants a 50% chance to evade damage from\n     enemies.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "32094",
@@ -5744,14 +5744,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋魔装脚の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中のキャラクターチップの枚数に応じ\n　　 攻撃の威力を超絶に強化する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts attack power by 230% + 10% x the\n     number of character chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 240% + 10% x the\n     number of character chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts attack power by 230% + 10% x the\n     number of character chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 240% + 10% x the\n     number of character chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "32097",
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中のキャラクターチップの枚数に応じ\n　　 攻撃の威力を極度に強化する。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts attack power by 250% + 10% x the\n     number of character chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 260% + 10% x the\n     number of character chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts attack power by 250% + 10% x the\n     number of character chips equipped.\n<color=yellow>SP: </color>Boosts attack power by 260% + 10% x the\n     number of character chips equipped.\n     <color=yellow>[Q-Frame]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n[Activation Trigger] Landing an attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "32098",
@@ -5961,14 +5961,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を大きく増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 50%.\n<color=yellow>SP: </color>Boosts damage effects by 60%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 50%.\n<color=yellow>SP: </color>Boosts damage effects by 60%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "32148",
 		"jp_explainShort": "定期的にＨＰが小回復＋大砲の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を劇的に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 70%.\n<color=yellow>SP: </color>Boosts damage effects by 80%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 70%.\n<color=yellow>SP: </color>Boosts damage effects by 80%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "32149",
@@ -6038,14 +6038,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋飛翔剣の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を劇的に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 105%.\n<color=yellow>SP: </color>Boosts damage effects by 115%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 105%.\n<color=yellow>SP: </color>Boosts damage effects by 115%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "32163",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を絶大に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 125%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Boosts damage effects by 125%.\n<color=yellow>SP: </color>Boosts damage effects by 135%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     successfully perform a Just Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by 30%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "32166",
@@ -6171,14 +6171,14 @@
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が雷属性の場合\n　　 攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts power of PAs and Techs by ???%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by ??% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts power of PAs and Techs by ???%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by ??% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32199",
 		"jp_explainShort": "ダメージ大増加＋定期的にＨＰが小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術の威力を絶大に強化する。\n② 装備中の武器の属性が雷属性の場合\n　　 攻撃力を大きく増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts power of PAs and Techs by ???%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by ??% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts power of PAs and Techs by ???%.\n     <color=yellow>[A-Frame]</color>\n②  Boosts damage by ??% if using a Dark weapon.\n     <color=yellow>[H-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32200",
@@ -6395,14 +6395,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アビリティレベルに応じて\n 　　ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by ???% + ?% x this\n     chip's ability level.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by ???% + ?% x this\n     chip's ability level.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32242",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アビリティレベルに応じて\n　　 ダメージ効果を超絶に増加する。\n② アクティブチップ使用か通常攻撃を行うごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by ???% + ?% x this\n     chip's ability level.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by ???% + ?% x this\n     chip's ability level.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32243",
@@ -6584,14 +6584,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋自在槍の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で特大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional ??% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Deals an additional ??% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32285",
 		"jp_explainShort": "定期的にＨＰが小回復＋長槍の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で絶大ダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Deals an additional ??% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Deals an additional ??% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32286",
@@ -6850,14 +6850,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋銃剣の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 攻撃対象の敵からダメージを受けた時\n　　 一定確率でランダムな状態異常効果を付与する。\n③ 状態異常の敵に対してダメージを超絶に増加する。\n④ 状態異常の敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 290% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 300% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n④  Reduces damage taken from enemies affected\n     by status effects by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 290% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 300% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n④  Reduces damage taken from enemies affected\n     by status effects by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 25 seconds"
 	},
 	{
 		"assign": "32336",
 		"jp_explainShort": "定期的にＨＰが小回復＋長銃の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃にランダムで特定の状態異常効果を付与する。\n② 攻撃対象の敵からダメージを受けた時\n　　 一定確率でランダムな状態異常効果を付与する。\n③ 状態異常の敵に対してダメージを極度に増加する。\n④ 状態異常の敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 310% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 320% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n④  Reduces damage taken from enemies affected\n     by status effects by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict random\n     status effects.\n②  Responds to damage from the targeted enemy\n     by inflicting random status effects.\n③  Boosts damage by 310% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 320% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n④  Reduces damage taken from enemies affected\n     by status effects by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] 30 seconds"
 	},
 	{
 		"assign": "32337",
@@ -6997,14 +6997,14 @@
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 属性によるダメージを超絶に増加する。\n② リンクスロットに装備したチップの種類が\n　　 キャラクターの場合\n　　 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n　　 ウェポノイドの場合\n　　 自身の通常攻撃と移動のスピードを加速する。\n　　 マグの場合、敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts elemental damage by ???%.\n     <color=yellow>[S-Frame]</color>\n②  If there is a Character chip in this chip's Link\n     Slot, all normal attacks, PAs and Techs become\n     Just Attacks.\n     If there is a Weaponoid chip in this chip's Link\n     Slot, speeds up movement and normal attacks\n     by ??%.\n     If there is a Mag chip in this chip's Link Slot,\n     grants a ??% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts elemental damage by ???%.\n     <color=yellow>[S-Frame]</color>\n②  If there is a Character chip in this chip's Link\n     Slot, all Normal Attacks, PAs and Techs become\n     Just Attacks.\n     If there is a Weaponoid chip in this chip's Link\n     Slot, speeds up movement and Normal Attacks\n     by ??%.\n     If there is a Mag chip in this chip's Link Slot,\n     grants a ??% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32363",
 		"jp_explainShort": "定期的にＨＰが小回復＋双小剣の技が大強化",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 属性によるダメージを超絶に増加する。\n② リンクスロットに装備したチップの種類が\n　　 キャラクターの場合\n　　 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n　　 ウェポノイドの場合\n　　 自身の通常攻撃と移動のスピードを加速する。\n　　 マグの場合、敵からの攻撃を一定確率で回避する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts elemental damage by ???%.\n     <color=yellow>[S-Frame]</color>\n②  If there is a Character chip in this chip's Link\n     Slot, all normal attacks, PAs and Techs become\n     Just Attacks.\n     If there is a Weaponoid chip in this chip's Link\n     Slot, speeds up movement and normal attacks\n     by ??%.\n     If there is a Mag chip in this chip's Link Slot,\n     grants a ??% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts elemental damage by ???%.\n     <color=yellow>[S-Frame]</color>\n②  If there is a Character chip in this chip's Link\n     Slot, all Normal Attacks, PAs and Techs become\n     Just Attacks.\n     If there is a Weaponoid chip in this chip's Link\n     Slot, speeds up movement and Normal Attacks\n     by ??%.\n     If there is a Mag chip in this chip's Link Slot,\n     grants a ??% chance to evade damage from\n     enemies.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32364",
@@ -7256,56 +7256,56 @@
 		"jp_explainShort": "氷属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で極度にダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間\n\n■特殊用途\nチップ解放（属性変換）を行うことで氷属性になる。",
-		"tr_explainLong": "①  Deals an additional 335% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 345% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds\n\n■Special Note\nBecomes Ice Element after Chip Release\n(Element Conversion)."
+		"tr_explainLong": "①  Deals an additional 335% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 345% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds\n\n■Special Note\nBecomes Ice Element after Chip Release\n(Element Conversion)."
 	},
 	{
 		"assign": "32412",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 敵に追加で極度にダメージを与える。\n② 通常攻撃・必殺技・法術が全てジャストアタックとなる。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間\n\n■特殊用途\nチップ解放（属性変換）を行うことで風属性になる。",
-		"tr_explainLong": "①  Deals an additional 335% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 345% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All normal attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds\n\n■Special Note\nBecomes Wind Element after Chip Release\n(Element Conversion)."
+		"tr_explainLong": "①  Deals an additional 335% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 345% damage to enemies.\n     <color=yellow>[Chase]</color>\n②  All Normal Attacks, PAs and Techs become Just\n     Attacks.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds\n\n■Special Note\nBecomes Wind Element after Chip Release\n(Element Conversion)."
 	},
 	{
 		"assign": "32413",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術チップが炎属性か氷属性の場合\n　　 装備中の炎・氷属性のチップの枚数に応じて\n　　 威力を絶大に増加する。\n② 炎・氷属性のチップの消費ＣＰを減少する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Fire and Ice PAs and Techs by\n     110% + 5% x the number of Fire and Ice\n     chips equipped.\n<color=yellow>SP: </color>Boosts Fire and Ice PAs and Techs by\n     120% + 5% x the number of Fire and Ice\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Fire and Ice chips.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts Fire and Ice PAs and Techs by\n     110% + 5% x the number of Fire and Ice\n     chips equipped.\n<color=yellow>SP: </color>Boosts Fire and Ice PAs and Techs by\n     120% + 5% x the number of Fire and Ice\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Fire and Ice chips.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32414",
 		"jp_explainShort": "風属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術チップが炎属性か氷属性の場合\n　　 装備中の炎・氷属性のチップの枚数に応じて\n　　 威力を絶大に増加する。\n② 炎・氷属性のチップの消費ＣＰを減少する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Fire and Ice PAs and Techs by\n     130% + 5% x the number of Fire and Ice\n     chips equipped.\n<color=yellow>SP: </color>Boosts Fire and Ice PAs and Techs by\n     140% + 5% x the number of Fire and Ice\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Fire and Ice chips.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts Fire and Ice PAs and Techs by\n     130% + 5% x the number of Fire and Ice\n     chips equipped.\n<color=yellow>SP: </color>Boosts Fire and Ice PAs and Techs by\n     140% + 5% x the number of Fire and Ice\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Fire and Ice chips.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32415",
 		"jp_explainShort": "風属性時増＋自在槍時増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術チップが光属性か闇属性の場合\n　　 装備中の光・闇属性のチップの枚数に応じて\n　　 威力を絶大に増加する。\n② 光・闇属性のチップの消費ＣＰを減少する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Light and Dark PAs and Techs by\n     110% + 5% x the number of Light and Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts Light and Dark PAs and Techs by\n     120% + 5% x the number of Light and Dark\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Light and Dark\n     chips.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts Light and Dark PAs and Techs by\n     110% + 5% x the number of Light and Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts Light and Dark PAs and Techs by\n     120% + 5% x the number of Light and Dark\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Light and Dark\n     chips.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32416",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術チップが光属性か闇属性の場合\n　　 装備中の光・闇属性のチップの枚数に応じて\n　　 威力を絶大に増加する。\n② 光・闇属性のチップの消費ＣＰを減少する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Light and Dark PAs and Techs by\n     130% + 5% x the number of Light and Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts Light and Dark PAs and Techs by\n     140% + 5% x the number of Light and Dark\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Light and Dark\n     chips.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts Light and Dark PAs and Techs by\n     130% + 5% x the number of Light and Dark\n     chips equipped.\n<color=yellow>SP: </color>Boosts Light and Dark PAs and Techs by\n     140% + 5% x the number of Light and Dark\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Light and Dark\n     chips.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32417",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術チップが雷属性か風属性の場合\n　　 装備中の雷・風属性のチップの枚数に応じて\n　　 威力を絶大に増加する。\n② 雷・風属性のチップの消費ＣＰを減少する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts Lightning and Wind PAs and Techs by\n     110% + 5% x the number of Lightning and Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts Lightning and Wind PAs and Techs by\n     120% + 5% x the number of Lightning and Wind\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Lightning and\n     Wind chips.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts Lightning and Wind PAs and Techs by\n     110% + 5% x the number of Lightning and Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts Lightning and Wind PAs and Techs by\n     120% + 5% x the number of Lightning and Wind\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Lightning and\n     Wind chips.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32418",
 		"jp_explainShort": "闇属性時小増＋自在槍時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 必殺技・法術チップが雷属性か風属性の場合\n　　 装備中の雷・風属性のチップの枚数に応じて\n　　 威力を絶大に増加する。\n② 雷・風属性のチップの消費ＣＰを減少する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts Lightning and Wind PAs and Techs by\n     130% + 5% x the number of Lightning and Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts Lightning and Wind PAs and Techs by\n     140% + 5% x the number of Lightning and Wind\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Lightning and\n     Wind chips.\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts Lightning and Wind PAs and Techs by\n     130% + 5% x the number of Lightning and Wind\n     chips equipped.\n<color=yellow>SP: </color>Boosts Lightning and Wind PAs and Techs by\n     140% + 5% x the number of Lightning and Wind\n     chips equipped.\n     <color=yellow>[K-Frame]</color>\n②  Reduces the CP consumption of Lightning and\n     Wind chips.\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32419",
@@ -7438,14 +7438,14 @@
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の炎・光属性のチップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 45% + 5% x the number of\n     Fire and Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% + 5% x the number of\n     Fire and Light chips equipped.\n     <color=yellow>[2A-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage by 45% + 5% x the number of\n     Fire and Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 50% + 5% x the number of\n     Fire and Light chips equipped.\n     <color=yellow>[2A-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32444",
 		"jp_explainShort": "風属性時小増＋双小剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 装備中の炎・光属性のチップの枚数に応じて\n　　 攻撃力を劇的に増加する。\n② 敵に追加で大ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 55% + 5% x the number of\n     Fire and Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% + 5% x the number of\n     Fire and Light chips equipped.\n     <color=yellow>[2A-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage by 55% + 5% x the number of\n     Fire and Light chips equipped.\n<color=yellow>SP: </color>Boosts damage by 60% + 5% x the number of\n     Fire and Light chips equipped.\n     <color=yellow>[2A-Frame]</color>\n②  Deals an additional 50% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Landing an attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32447",
@@ -7669,28 +7669,28 @@
 		"jp_explainShort": "氷属性時小増＋銃剣時小増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by 240%.\n<color=yellow>SP: </color>Boosts damage effects by 250%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32492",
 		"jp_explainShort": "氷属性時増＋銃剣時増＋定期ＨＰ小回復",
 		"tr_explainShort": "",
 		"jp_explainLong": "① ダメージ効果を超絶に増加する。\n② ジャストアタックを成功させるごとに\n　　 ダメージ効果をわずかに増加する。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a normal attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and normal attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Boosts damage effects by 260%.\n<color=yellow>SP: </color>Boosts damage effects by 270%.\n     <color=yellow>[Z-Frame]</color>\n②  Boosts damage effects by 1% each time you\n     use an active chip or a Normal Attack.\n     <color=yellow>[Z-Frame]</color>\n③  Speeds up movement and Normal Attacks by ??%.\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32493",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」の状態異常効果を付与する。\n② 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「ポイズン」効果を与える。\n③ 状態異常の敵に対してダメージを絶大に増加する。\n④ 状態異常の敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Responds to damage from the targeted enemy\n     with a chance to inflict [Poison].\n③  Boosts damage by 120% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 130% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n②  Responds to damage from the targeted enemy\n     with a chance to inflict [Poison].\n③  Boosts damage by 120% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 130% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32494",
 		"jp_explainShort": "-",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」の状態異常効果を付与する。\n② 攻撃対象の敵からダメージを受けた時\n　　 一定確率で「ポイズン」効果を与える。\n③ 状態異常の敵に対してダメージを絶大に増加する。\n④ 状態異常の敵から受けるダメージを軽減する。\n[発動条件]ジャストアタック成功時\n[効果時間]長い時間",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n②  Responds to damage from the targeted enemy\n     with a chance to inflict [Poison].\n③  Boosts damage by 140% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 150% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n②  Responds to damage from the targeted enemy\n     with a chance to inflict [Poison].\n③  Boosts damage by 140% against enemies\n     affected by status effects.\n<color=yellow>SP: </color>Boosts damage by 150% against enemies\n     affected by status effects.\n     <color=yellow>[C-Frame]</color>\n[Activation Trigger] Successful Just Attack\n[Effect Duration] ?? seconds"
 	},
 	{
 		"assign": "32495",
@@ -11253,14 +11253,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "3720",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「ポイズン」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Poison].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "4210",
@@ -11407,14 +11407,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵に追加で小ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20048",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 敵に追加で小ダメージを与える。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃ヒット時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Deals an additional 15% damage to enemies.\n     <color=yellow>[Chase]</color>\n③  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "5610",
@@ -11701,14 +11701,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "9020",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 通常攻撃に「パニック」効果を付与する。\n[発動条件]攻撃がヒットした時",
-		"tr_explainLong": "①  Gives normal attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
+		"tr_explainLong": "①  Gives Normal Attacks a chance to inflict [Panic].\n[Activation Trigger] Landing an attack"
 	},
 	{
 		"assign": "20023",
@@ -11743,14 +11743,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 光属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Light Element by 60.\n<color=yellow>SP: </color>Increases your Light Element by 65.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your Light Element by 60.\n<color=yellow>SP: </color>Increases your Light Element by 65.\n②  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20032",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 光属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 75.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your Light Element by 70.\n<color=yellow>SP: </color>Increases your Light Element by 75.\n②  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "9510",
@@ -11799,14 +11799,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：大）\n② 敵に追加で小ダメージを与える。\n[発動条件]スライド操作時\n[効果時間]短い時間",
-		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 500)\n②  Deals an additional 15% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 20% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
+		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 500)\n②  Deals an additional 15% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 20% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 10 seconds"
 	},
 	{
 		"assign": "20034",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① アクティブチップ使用か通常攻撃を３回行うごとに\n　　 攻撃力をわずかに強化する。（最大時：大）\n② 敵に追加で小ダメージを与える。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a normal attack.\n     (Maximum increase: 500)\n②  Deals an additional 25% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your ATK by 100 every 3 times you\n     use an active chip or a Normal Attack.\n     (Maximum increase: 500)\n②  Deals an additional 25% damage to enemies.\n<color=yellow>SP: </color>Deals an additional 30% damage to enemies.\n     <color=yellow>[Chase]</color>\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20039",
@@ -11883,14 +11883,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage\n     up to 5% of your maximum HP.\n<color=yellow>SP: </color>Grants you a shield that prevents damage\n     up to 10% of your maximum HP.\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Boosts damage by 10%.\n<color=yellow>SP: </color>Boosts damage by 15%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage\n     up to 5% of your maximum HP.\n<color=yellow>SP: </color>Grants you a shield that prevents damage\n     up to 10% of your maximum HP.\n③  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20052",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 攻撃力をわずかに増加する。\n② 一定ダメージを防ぐ効果をＨＰに上乗せする。\n③ 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]攻撃がヒットした時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage\n     up to 10% of your maximum HP.\n<color=yellow>SP: </color>Grants you a shield that prevents damage\n     up to 15% of your maximum HP.\n③  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
+		"tr_explainLong": "①  Boosts damage by 20%.\n<color=yellow>SP: </color>Boosts damage by 25%.\n     <color=yellow>[E-Frame]</color>\n②  Grants you a shield that prevents damage\n     up to 10% of your maximum HP.\n<color=yellow>SP: </color>Grants you a shield that prevents damage\n     up to 15% of your maximum HP.\n③  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Landing an attack\n[Effect Duration] 20 seconds"
 	},
 	{
 		"assign": "20055",
@@ -11939,14 +11939,14 @@
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 65.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your Dark Element by 60.\n<color=yellow>SP: </color>Increases your Dark Element by 65.\n②  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20062",
 		"jp_explainShort": "",
 		"tr_explainShort": "",
 		"jp_explainLong": "① 闇属性を大きく強化する。\n② 自身の通常攻撃と移動のスピードを加速する。\n[発動条件]スライド操作時\n[効果時間]一定時間",
-		"tr_explainLong": "①  Increases your Dark Element by 70.\n<color=yellow>SP: </color>Increases your Dark Element by 75.\n②  Speeds up movement and normal attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
+		"tr_explainLong": "①  Increases your Dark Element by 70.\n<color=yellow>SP: </color>Increases your Dark Element by 75.\n②  Speeds up movement and Normal Attacks by 15%.\n[Activation Trigger] Slide Action\n[Effect Duration] 15 seconds"
 	},
 	{
 		"assign": "20063",

--- a/json/Explain_Element_Booster.txt
+++ b/json/Explain_Element_Booster.txt
@@ -886,7 +886,7 @@
 		"jp_text": "ギフトレセプター",
 		"tr_text": "Gift Receptor",
 		"jp_explain": "ギフト系特殊能力の\n引き継ぎが可能になる\n全+10",
-		"tr_explain": "Allows transfer of gift-type\nspecial abilities.\nAll +10"
+		"tr_explain": "Allows transfer of gift-type\nSpecial Abilities.\nAll +10"
 	},
 	{
 		"assign": "127",
@@ -1831,7 +1831,7 @@
 		"jp_text": "マークレセプター",
 		"tr_text": "Mark Receptor",
 		"jp_explain": "マーク系特殊能力の\n継承成功率を大幅に上昇\n全+10",
-		"tr_explain": "Allows transfer of Mark-type\nspecial abilities.\nAll +10"
+		"tr_explain": "Allows transfer of Mark-type\nSpecial Abilities.\nAll +10"
 	},
 	{
 		"assign": "262",

--- a/json/Explain_Element_UserSkill.txt
+++ b/json/Explain_Element_UserSkill.txt
@@ -1271,7 +1271,7 @@
 		"jp_text": "Ｓ４：短杖強打",
 		"tr_text": "S4:Wand Clobber",
 		"jp_explain": "ウォンドの通常攻撃\n性能が強化される。",
-		"tr_explain": "Enhances Wand's\nnormal attacks."
+		"tr_explain": "Enhances Wand's\nNormal Attacks."
 	},
 	{
 		"assign": "182",
@@ -2909,7 +2909,7 @@
 		"jp_text": "Ｓ４：静心の志",
 		"tr_text": "S4:Calming Intent",
 		"jp_explain": "通常攻撃の威力が\n13％上昇。",
-		"tr_explain": "Boosts normal attack\ndamage by 13%."
+		"tr_explain": "Boosts Normal Attack\ndamage by 13%."
 	},
 	{
 		"assign": "416",
@@ -3357,7 +3357,7 @@
 		"jp_text": "Ｓ３：静心活与",
 		"tr_text": "S3:Calming Exhilaration",
 		"jp_explain": "通常攻撃が命中した時\nＨＰが70回復。\n発動後リキャスト発生。",
-		"tr_explain": "Recovers 70 HP when\nyou hit with a normal\nattack. Has a cooldown\nbetween activations."
+		"tr_explain": "Recovers 70 HP when\nyou hit with a Normal\nAttack. Has a cooldown\nbetween activations."
 	},
 	{
 		"assign": "480",

--- a/json/Explain_Element_UserSkill.txt
+++ b/json/Explain_Element_UserSkill.txt
@@ -3259,7 +3259,7 @@
 		"jp_text": "Ｓ１：打撃増幅",
 		"tr_text": "S1:Strike Boost",
 		"jp_explain": "特殊能力の追加打撃力\n60毎に、威力1％上昇し\n200以上で更に2％上昇。",
-		"tr_explain": "Boosts power by 1% for every\n60 S-ATK\nof special abilities\nadded to the item,\nand boosts by a further 2% at 200+."
+		"tr_explain": "Boosts power by 1% for every\n60 S-ATK\nof Special Abilities\nadded to the item,\nand boosts by a further 2% at 200+."
 	},
 	{
 		"assign": "466",
@@ -3280,7 +3280,7 @@
 		"jp_text": "Ｓ１：射撃増幅",
 		"tr_text": "S1:Shoot Boost",
 		"jp_explain": "特殊能力の追加射撃力\n60毎に、威力1％上昇し\n200以上で更に2％上昇。",
-		"tr_explain": "Boosts power by 1%\nfor every 60 R-ATK\nof special abilities\nadded to the item,\nand boosts by a\nfurther 2% at 200+."
+		"tr_explain": "Boosts power by 1%\nfor every 60 R-ATK\nof Special Abilities\nadded to the item,\nand boosts by a\nfurther 2% at 200+."
 	},
 	{
 		"assign": "469",
@@ -3301,7 +3301,7 @@
 		"jp_text": "Ｓ１：法撃増幅",
 		"tr_text": "S1:Tech Boost",
 		"jp_explain": "特殊能力の追加法撃力\n60毎に、威力1％上昇し\n200以上で更に2％上昇。",
-		"tr_explain": "Boosts power by 1%\nfor every 60 T-ATK\nof special abilities\nadded to the item,\nand boosts by a\nfurther 2% at 200+."
+		"tr_explain": "Boosts power by 1%\nfor every 60 T-ATK\nof Special Abilities\nadded to the item,\nand boosts by a\nfurther 2% at 200+."
 	},
 	{
 		"assign": "472",
@@ -3322,7 +3322,7 @@
 		"jp_text": "Ｓ１：錬成の志",
 		"tr_text": "S1:Augment Intent",
 		"jp_explain": "特殊能力の付与数に\n応じて威力上昇。\n最大で4％。",
-		"tr_explain": "Boosts power by 0.5%\nfor each special ability\nadded to the item."
+		"tr_explain": "Boosts power by 0.5%\nfor each Special Ability\nadded to the item."
 	},
 	{
 		"assign": "475",

--- a/json/Explain_Element_UserSkill2.txt
+++ b/json/Explain_Element_UserSkill2.txt
@@ -165,7 +165,7 @@
 		"jp_text": "Ｓ５：静心杖弾",
 		"tr_text": "S5:Calming Bullet",
 		"jp_explain": "通常攻撃性能が強化され\nロッドシュートの威力が\n100％上昇する。\n長杖限定。",
-		"tr_explain": "Enhances normal\nattacks and boosts the\npower of Rod Shoot by\n100%. Rod only."
+		"tr_explain": "Enhances Normal\nAttacks and boosts the\npower of Rod Shoot by\n100%. Rod only."
 	},
 	{
 		"assign": "24",
@@ -179,7 +179,7 @@
 		"jp_text": "Ｓ５：静心衝杖",
 		"tr_text": "S5:Calming Shockwave",
 		"jp_explain": "通常攻撃の3段目に\n衝撃波が発生。\n威力2％上昇。短杖限定。",
-		"tr_explain": "Unleashes a shockwave\non your third step\nnormal attack. Boosts\ndamage by 2%. Wand\nonly."
+		"tr_explain": "Unleashes a shockwave\non your third step\nNormal Attack. Boosts\ndamage by 2%. Wand\nonly."
 	},
 	{
 		"assign": "26",
@@ -382,14 +382,14 @@
 		"jp_text": "Ｓ５：静心四連",
 		"tr_text": "S5:Calming Quartet",
 		"jp_explain": "通常攻撃の威力が\n67％低下する代わりに\n攻撃が4発に変化。\n大砲限定。",
-		"tr_explain": "Reduces the power of\nnormal attacks by 67%,\nbut makes each normal\nattack fire 4 shots.\nLaunchers only."
+		"tr_explain": "Reduces the power of\nNormal Attacks by 67%,\nbut makes each Normal\nAttack fire 4 shots.\nLaunchers only."
 	},
 	{
 		"assign": "55",
 		"jp_text": "Ｓ５：静心拡域",
 		"tr_text": "S5:Calming Expanse",
 		"jp_explain": "通常攻撃に\n範囲攻撃が追加され\n確率でスタン付与。\n威力2％上昇。長銃限定。",
-		"tr_explain": "Adds an extra wide-area\nattack and a chance to\nstun to normal attacks.\nBoosts damage by 2%.\nAssault Rifles only."
+		"tr_explain": "Adds an extra wide-area\nattack and a chance to\nstun to Normal Attacks.\nBoosts damage by 2%.\nAssault Rifles only."
 	},
 	{
 		"assign": "56",

--- a/json/Explain_Element_UserSkill2.txt
+++ b/json/Explain_Element_UserSkill2.txt
@@ -116,7 +116,7 @@
 		"jp_text": "Ｓ５：錬成萌花",
 		"tr_text": "S5:Anthesis Cultivation",
 		"jp_explain": "特殊能力の\nステータス変化を\n2倍にする。",
-		"tr_explain": "Doubles the effects\nof special abilities."
+		"tr_explain": "Doubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "17",
@@ -508,7 +508,7 @@
 		"jp_text": "Ｓ１：錬成の志２",
 		"tr_text": "S1:Augment Intent 2",
 		"jp_explain": "特殊能力の付与数に\n応じて威力上昇。\n最大で6％。",
-		"tr_explain": "Boosts power\nfor each special ability\nadded to the item.\nMax: 6%."
+		"tr_explain": "Boosts power\nfor each Special Ability\nadded to the item.\nMax: 6%."
 	},
 	{
 		"assign": "73",
@@ -1411,7 +1411,7 @@
 		"jp_text": "Ｓ６：英雄咆哮",
 		"tr_text": "S6:Heroic Howl",
 		"jp_explain": "ヒーローブースト強化。\n威力増加速度が上昇。\n「英雄の凱歌」が\n優先され併用不可。",
-		"tr_explain": "Enhances the effect\nof Hero Boost's\ndamage bonus\naccumulation rate.\nDoes not work with\nthe \"Heroic Victory\"\npotential."
+		"tr_explain": "Enhances the effect\nof Hero Boost's\ndamage bonus\naccumulation rate.\nDoes not work with\nthe \"Heroic Victory\"\nPotential."
 	},
 	{
 		"assign": "202",

--- a/json/Explain_Potential.txt
+++ b/json/Explain_Potential.txt
@@ -19534,70 +19534,70 @@
 		"jp_text": "錬成開花 Lv.1",
 		"tr_text": "Anthesis Trainer Lv.1",
 		"jp_explain": "威力が10％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 10%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 10%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302382015",
 		"jp_text": "錬成開花 Lv.2",
 		"tr_text": "Anthesis Trainer Lv.2",
 		"jp_explain": "威力が12％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 12%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 12%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302382014",
 		"jp_text": "錬成開花 Lv.3",
 		"tr_text": "Anthesis Trainer Lv.3",
 		"jp_explain": "威力が14％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 14%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 14%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302382009",
 		"jp_text": "錬成開花 Lv.4",
 		"tr_text": "Anthesis Trainer Lv.4",
 		"jp_explain": "威力が16％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 16%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 16%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302382008",
 		"jp_text": "錬成開花 Lv.5",
 		"tr_text": "Anthesis Trainer Lv.5",
 		"jp_explain": "威力が18％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 18%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 18%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302377869",
 		"jp_text": "錬成開花 Lv.1",
 		"tr_text": "Anthesis Trainer Lv.1",
 		"jp_explain": "威力が10％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 10%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 10%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302377870",
 		"jp_text": "錬成開花 Lv.2",
 		"tr_text": "Anthesis Trainer Lv.2",
 		"jp_explain": "威力が12％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 12%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 12%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302377871",
 		"jp_text": "錬成開花 Lv.3",
 		"tr_text": "Anthesis Trainer Lv.3",
 		"jp_explain": "威力が14％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 14%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 14%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302377864",
 		"jp_text": "錬成開花 Lv.4",
 		"tr_text": "Anthesis Trainer Lv.4",
 		"jp_explain": "威力が16％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 16%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 16%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "302377865",
 		"jp_text": "錬成開花 Lv.5",
 		"tr_text": "Anthesis Trainer Lv.5",
 		"jp_explain": "威力が18％上昇。\n特殊能力のステータス\n変化を2倍にする。",
-		"tr_explain": "Boosts damage by 18%.\nDoubles the effects\nof special abilities."
+		"tr_explain": "Boosts damage by 18%.\nDoubles the effects\nof Special Abilities."
 	},
 	{
 		"assign": "104139527",
@@ -20269,35 +20269,35 @@
 		"jp_text": "錬成練化 Lv.1",
 		"tr_text": "Tempering Trainer Lv.1",
 		"jp_explain": "特殊能力数に応じて\n威力が上昇し\nＰＰ消費量が減少する。",
-		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nspecial abilities added\nto the weapon."
+		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nSpecial Abilities added\nto the weapon."
 	},
 	{
 		"assign": "1440568571",
 		"jp_text": "錬成練化 Lv.2",
 		"tr_text": "Tempering Trainer Lv.2",
 		"jp_explain": "特殊能力数に応じて\n威力が上昇し\nＰＰ消費量が減少する。",
-		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nspecial abilities added\nto the weapon."
+		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nSpecial Abilities added\nto the weapon."
 	},
 	{
 		"assign": "1440568572",
 		"jp_text": "錬成練化 Lv.3",
 		"tr_text": "Tempering Trainer Lv.3",
 		"jp_explain": "特殊能力数に応じて\n威力が上昇し\nＰＰ消費量が減少する。",
-		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nspecial abilities added\nto the weapon."
+		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nSpecial Abilities added\nto the weapon."
 	},
 	{
 		"assign": "1440568573",
 		"jp_text": "錬成練化 Lv.4",
 		"tr_text": "Tempering Trainer Lv.4",
 		"jp_explain": "特殊能力数に応じて\n威力が上昇し\nＰＰ消費量が減少する。",
-		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nspecial abilities added\nto the weapon."
+		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nSpecial Abilities added\nto the weapon."
 	},
 	{
 		"assign": "1440568574",
 		"jp_text": "錬成練化 Lv.5",
 		"tr_text": "Tempering Trainer Lv.5",
 		"jp_explain": "特殊能力数に応じて\n威力が上昇し\nＰＰ消費量が減少する。",
-		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nspecial abilities added\nto the weapon."
+		"tr_explain": "Boosts damage and\nreduces PP consumption\nbased on the number of\nSpecial Abilities added\nto the weapon."
 	},
 	{
 		"assign": "279024015",

--- a/json/Explain_Potential.txt
+++ b/json/Explain_Potential.txt
@@ -13374,35 +13374,35 @@
 		"jp_text": "連鎖の旋律 Lv.1",
 		"tr_text": "Chaining Melody Lv.1",
 		"jp_explain": "チェインフィニッシュの\n成功時、チェイン数に応じ\nリキャストを軽減する。",
-		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non chain count when\nperforming Chain Finish."
+		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non Chain Count when\nperforming Chain Finish."
 	},
 	{
 		"assign": "1142983944",
 		"jp_text": "連鎖の旋律 Lv.2",
 		"tr_text": "Chaining Melody Lv.2",
 		"jp_explain": "チェインフィニッシュの\n成功時、チェイン数に応じ\nリキャストを軽減する。",
-		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non chain count when\nperforming Chain Finish."
+		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non Chain Count when\nperforming Chain Finish."
 	},
 	{
 		"assign": "1142983945",
 		"jp_text": "連鎖の旋律 Lv.3",
 		"tr_text": "Chaining Melody Lv.3",
 		"jp_explain": "チェインフィニッシュの\n成功時、チェイン数に応じ\nリキャストを軽減する。",
-		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non chain count when\nperforming Chain Finish."
+		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non Chain Count when\nperforming Chain Finish."
 	},
 	{
 		"assign": "1142983942",
 		"jp_text": "連鎖の旋律 Lv.4",
 		"tr_text": "Chaining Melody Lv.4",
 		"jp_explain": "チェインフィニッシュの\n成功時、チェイン数に応じ\nリキャストを軽減する。",
-		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non chain count when\nperforming Chain Finish."
+		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non Chain Count when\nperforming Chain Finish."
 	},
 	{
 		"assign": "1142983943",
 		"jp_text": "連鎖の旋律 Lv.5",
 		"tr_text": "Chaining Melody Lv.5",
 		"jp_explain": "チェインフィニッシュの\n成功時、チェイン数に応じ\nリキャストを軽減する。",
-		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non chain count when\nperforming Chain Finish."
+		"tr_explain": "Reduces the cooldown\nof Chain Trigger based\non Chain Count when\nperforming Chain Finish."
 	},
 	{
 		"assign": "388798038",

--- a/json/Explain_Potential.txt
+++ b/json/Explain_Potential.txt
@@ -13444,35 +13444,35 @@
 		"jp_text": "封龍の咆哮 Lv.1",
 		"tr_text": "Sealing Dragon's Roar Lv.1",
 		"jp_explain": "通常攻撃の与ダメージが\n60％上昇する。",
-		"tr_explain": "Boosts the damage of\nnormal attacks by 60%."
+		"tr_explain": "Boosts the damage of\nNormal Attacks by 60%."
 	},
 	{
 		"assign": "2013910696",
 		"jp_text": "封龍の咆哮 Lv.2",
 		"tr_text": "Sealing Dragon's Roar Lv.2",
 		"jp_explain": "通常攻撃の与ダメージが\n70％上昇する。",
-		"tr_explain": "Boosts the damage of\nnormal attacks by 70%."
+		"tr_explain": "Boosts the damage of\nNormal Attacks by 70%."
 	},
 	{
 		"assign": "2013910697",
 		"jp_text": "封龍の咆哮 Lv.3",
 		"tr_text": "Sealing Dragon's Roar Lv.3",
 		"jp_explain": "通常攻撃の与ダメージが\n80％上昇する。",
-		"tr_explain": "Boosts the damage of\nnormal attacks by 80%"
+		"tr_explain": "Boosts the damage of\nNormal Attacks by 80%"
 	},
 	{
 		"assign": "2013910698",
 		"jp_text": "封龍の咆哮 Lv.4",
 		"tr_text": "Sealing Dragon's Roar Lv.4",
 		"jp_explain": "通常攻撃の与ダメージが\n90％上昇する。",
-		"tr_explain": "Boosts the damage of\nnormal attacks by 90%."
+		"tr_explain": "Boosts the damage of\nNormal Attacks by 90%."
 	},
 	{
 		"assign": "2013910699",
 		"jp_text": "封龍の咆哮 Lv.5",
 		"tr_text": "Sealing Dragon's Roar Lv.5",
 		"jp_explain": "通常攻撃の与ダメージが\n100％上昇する。",
-		"tr_explain": "Boosts the damage of\nnormal attacks by 100%."
+		"tr_explain": "Boosts the damage of\nNormal Attacks by 100%."
 	},
 	{
 		"assign": "3463001454",
@@ -17469,35 +17469,35 @@
 		"jp_text": "飛斬翔刃 Lv.1",
 		"tr_text": "Dissipating Wave Lv.1",
 		"jp_explain": "通常攻撃時に斬撃が飛ぶ。",
-		"tr_explain": "Adds an energy wave\nprojectile to normal\nattacks."
+		"tr_explain": "Adds an energy wave\nprojectile to Normal\nAttacks."
 	},
 	{
 		"assign": "3504509036",
 		"jp_text": "飛斬翔刃 Lv.2",
 		"tr_text": "Dissipating Wave Lv.2",
 		"jp_explain": "通常攻撃時に斬撃が飛ぶ。",
-		"tr_explain": "Adds an energy wave\nprojectile to normal\nattacks."
+		"tr_explain": "Adds an energy wave\nprojectile to Normal\nAttacks."
 	},
 	{
 		"assign": "3504509039",
 		"jp_text": "飛斬翔刃 Lv.3",
 		"tr_text": "Dissipating Wave Lv.3",
 		"jp_explain": "通常攻撃時に斬撃が飛ぶ。",
-		"tr_explain": "Adds an energy wave\nprojectile to normal\nattacks."
+		"tr_explain": "Adds an energy wave\nprojectile to Normal\nAttacks."
 	},
 	{
 		"assign": "3504509038",
 		"jp_text": "飛斬翔刃 Lv.4",
 		"tr_text": "Dissipating Wave Lv.4",
 		"jp_explain": "通常攻撃時に斬撃が飛ぶ。",
-		"tr_explain": "Adds an energy wave\nprojectile to normal\nattacks."
+		"tr_explain": "Adds an energy wave\nprojectile to Normal\nAttacks."
 	},
 	{
 		"assign": "3504509025",
 		"jp_text": "飛斬翔刃 Lv.5",
 		"tr_text": "Dissipating Wave Lv.5",
 		"jp_explain": "通常攻撃時に斬撃が飛ぶ。",
-		"tr_explain": "Adds an energy wave\nprojectile to normal\nattacks."
+		"tr_explain": "Adds an energy wave\nprojectile to Normal\nAttacks."
 	},
 	{
 		"assign": "614156037",
@@ -17889,35 +17889,35 @@
 		"jp_text": "極限解放 Lv.1",
 		"tr_text": "Limit Release Lv.1",
 		"jp_explain": "PP消費量が10％増加し\n通常攻撃の与ダメージが\n70％上昇する。",
-		"tr_explain": "Increases PP costs by\n10%, but boosts normal\nattack damage by 70%."
+		"tr_explain": "Increases PP costs by\n10%, but boosts Normal\nAttack damage by 70%."
 	},
 	{
 		"assign": "574441002",
 		"jp_text": "極限解放 Lv.2",
 		"tr_text": "Limit Release Lv.2",
 		"jp_explain": "PP消費量が10％増加し\n通常攻撃の与ダメージが\n76％上昇する。",
-		"tr_explain": "Increases PP costs by\n10%, but boosts normal\nattack damage by 76%."
+		"tr_explain": "Increases PP costs by\n10%, but boosts Normal\nAttack damage by 76%."
 	},
 	{
 		"assign": "574441003",
 		"jp_text": "極限解放 Lv.3",
 		"tr_text": "Limit Release Lv.3",
 		"jp_explain": "PP消費量が10％増加し\n通常攻撃の与ダメージが\n82％上昇する。",
-		"tr_explain": "Increases PP costs by\n10%, but boosts normal\nattack damage by 82%."
+		"tr_explain": "Increases PP costs by\n10%, but boosts Normal\nAttack damage by 82%."
 	},
 	{
 		"assign": "574441000",
 		"jp_text": "極限解放 Lv.4",
 		"tr_text": "Limit Release Lv.4",
 		"jp_explain": "PP消費量が30％増加し\n通常攻撃の与ダメージが\n200％上昇する。",
-		"tr_explain": "Increases PP costs by\n10%, but boosts normal\nattack damage by 200%."
+		"tr_explain": "Increases PP costs by\n10%, but boosts Normal\nAttack damage by 200%."
 	},
 	{
 		"assign": "574441001",
 		"jp_text": "極限解放 Lv.5",
 		"tr_text": "Limit Release Lv.5",
 		"jp_explain": "PP消費量が30％増加し\n通常攻撃の与ダメージが\n200％上昇する。",
-		"tr_explain": "Increases PP costs by\n10%, but boosts normal\nattack damage by 200%."
+		"tr_explain": "Increases PP costs by\n10%, but boosts Normal\nAttack damage by 200%."
 	},
 	{
 		"assign": "340112702",
@@ -23804,35 +23804,35 @@
 		"jp_text": "白銀の輝焔 Lv.1",
 		"tr_text": "Bright Silver Flame Lv.1",
 		"jp_explain": "威力が6％上昇。\n通常攻撃の3段目が\n爆発弾に変わる。",
-		"tr_explain": "Boosts power by 6%.\nThe third normal\nattack becomes an\nexplosive bullet."
+		"tr_explain": "Boosts power by 6%.\nThe third Normal\nAttack becomes an\nexplosive bullet."
 	},
 	{
 		"assign": "2147915484",
 		"jp_text": "白銀の輝焔 Lv.2",
 		"tr_text": "Bright Silver Flame Lv.2",
 		"jp_explain": "威力が8％上昇。\n通常攻撃の3段目が\n爆発弾に変わる。",
-		"tr_explain": "Boosts power by 8%.\nThe third normal\nattack becomes an\nexplosive bullet."
+		"tr_explain": "Boosts power by 8%.\nThe third Normal\nAttack becomes an\nexplosive bullet."
 	},
 	{
 		"assign": "2147915459",
 		"jp_text": "白銀の輝焔 Lv.3",
 		"tr_text": "Bright Silver Flame Lv.3",
 		"jp_explain": "威力が10％上昇。\n通常攻撃の3段目が\n爆発弾に変わる。",
-		"tr_explain": "Boosts power by 10%.\nThe third normal\nattack becomes an\nexplosive bullet."
+		"tr_explain": "Boosts power by 10%.\nThe third Normal\nAttack becomes an\nexplosive bullet."
 	},
 	{
 		"assign": "2147915458",
 		"jp_text": "白銀の輝焔 Lv.4",
 		"tr_text": "Bright Silver Flame Lv.4",
 		"jp_explain": "威力が12％上昇。\n通常攻撃の3段目が\n爆発弾に変わる。",
-		"tr_explain": "Boosts power by 12%.\nThe third normal\nattack becomes an\nexplosive bullet."
+		"tr_explain": "Boosts power by 12%.\nThe third Normal\nAttack becomes an\nexplosive bullet."
 	},
 	{
 		"assign": "2147915457",
 		"jp_text": "白銀の輝焔 Lv.5",
 		"tr_text": "Bright Silver Flame Lv.5",
 		"jp_explain": "威力が14％上昇。\n通常攻撃の3段目が\n爆発弾に変わる。",
-		"tr_explain": "Boosts power by 14%.\nThe third normal\nattack becomes an\nexplosive bullet."
+		"tr_explain": "Boosts power by 14%.\nThe third Normal\nAttack becomes an\nexplosive bullet."
 	},
 	{
 		"assign": "4056837856",

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -60,7 +60,7 @@
 		"jp_text": "アタックアドバンス",
 		"tr_text": "Attack Advance",
 		"jp_explain": "アタックアドバンス／リング\n通常攻撃の威力が上昇する。",
-		"tr_explain": "Attack Advance/Ring\nIncreases normal attack power."
+		"tr_explain": "Attack Advance/Ring\nIncreases Normal Attack power."
 	},
 	{
 		"assign": "12",
@@ -109,14 +109,14 @@
 		"jp_text": "ＴＤエアチェイス",
 		"tr_text": "TD Air Chase",
 		"jp_explain": "ツインダガーエアチェイス\nツインダガーの空中での通常攻撃と一部のＰＡに\nロックした敵へ近づく挙動が追加される。",
-		"tr_explain": "Twin Dagger Air Chase Normal\nattacks and certain PAs in the air will\nchase a locked on target."
+		"tr_explain": "Twin Dagger Air Chase Normal\nAttacks and certain PAs in the air will\nchase a locked on target."
 	},
 	{
 		"assign": "19",
 		"jp_text": "ナックルチェイス",
 		"tr_text": "Knuckle Chase",
 		"jp_explain": "ナックルチェイス\nナックルの地上での通常攻撃と一部のＰＡに\nロックした敵へ近づく挙動が追加される。",
-		"tr_explain": "Knuckle Chase Normal attacks and\ncertain PA's on the ground will chase\nlocked-on enemies."
+		"tr_explain": "Knuckle Chase Normal Attacks and\ncertain PA's on the ground will chase\nlocked-on enemies."
 	},
 	{
 		"assign": "20",
@@ -249,7 +249,7 @@
 		"jp_text": "バレットボウホーミング",
 		"tr_text": "Bullet Bow Homing",
 		"jp_explain": "バレットボウホーミング\nバレットボウのチャージ通常攻撃に\n誘導性能が追加される。",
-		"tr_explain": "Bullet Bow Homing\nAdds a homing ability to a\nbullet bow's charged normal attack."
+		"tr_explain": "Bullet Bow Homing\nAdds a homing ability to a\nbullet bow's charged Normal Attack."
 	},
 	{
 		"assign": "42",
@@ -270,7 +270,7 @@
 		"jp_text": "Ａランチャーモード",
 		"tr_text": "A. Launcher Mode",
 		"jp_explain": "アナザーランチャーモード\nランチャーの通常攻撃の弾道が変化し\n威力が上昇。攻撃範囲も広がる。",
-		"tr_explain": "Another Launcher Mode Changes the\ntrajectory and boosts the power of a\nlauncher's normal attack. Attack\nrange is also increased."
+		"tr_explain": "Another Launcher Mode Changes the\ntrajectory and boosts the power of a\nlauncher's Normal Attack. Attack\nrange is also increased."
 	},
 	{
 		"assign": "45",

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -606,7 +606,7 @@
 		"jp_text": "TマシンガンＳアップ",
 		"tr_text": "T. Machinegun S-Up",
 		"jp_explain": "ツインマシンガンスタンスアップ\nツインマシンガンを装備している間\nスタンススキルの効果に打撃・射撃威力上昇を追加。",
-		"tr_explain": "Twin Machinegun Stance Up Adds\nincreased S-ATK and R-ATK to\nstance skill effects when Twin\nMachineguns are equipped."
+		"tr_explain": "Twin Machinegun Stance Up\nAdds increased S-ATK and R-ATK\nto stance skill effects while\nTwin Machineguns are equipped."
 	},
 	{
 		"assign": "91",

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -137,7 +137,7 @@
 		"jp_text": "ＤＢスナッチ",
 		"tr_text": "DB Snatch",
 		"jp_explain": "デュアルブレードスナッチ\nデュアルブレードの武器アクションで移動した時\n敵に打撃ダメージを与える挙動が追加される。",
-		"tr_explain": "Dual Blade Snatch Inflicts striking\ndamage to enemies while moving\nusing the Dual Blade weapon action."
+		"tr_explain": "Dual Blade Snatch Inflicts striking\ndamage to enemies while moving\nusing the Dual Blade Weapon Action."
 	},
 	{
 		"assign": "23",
@@ -522,7 +522,7 @@
 		"jp_text": "スローＦｉアクション",
 		"tr_text": "Slow Fi Action",
 		"jp_explain": "スローファイターアクション\nファイター武器で行う武器アクションの速度を落とし\n継続時間を延長する。",
-		"tr_explain": "Slow Fighter Action\nExtends the duration and reduces\nthe speed of Fighter weapon actions."
+		"tr_explain": "Slow Fighter Action\nExtends the duration and reduces\nthe speed of Fighter Weapon Actions."
 	},
 	{
 		"assign": "76",

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -606,7 +606,7 @@
 		"jp_text": "TマシンガンＳアップ",
 		"tr_text": "T. Machinegun S-Up",
 		"jp_explain": "ツインマシンガンスタンスアップ\nツインマシンガンを装備している間\nスタンススキルの効果に打撃・射撃威力上昇を追加。",
-		"tr_explain": "Twin Machinegun Stance Up Adds\nincreased S-ATK and R-ATK to\nstance skill effects when a Twin\nMachinegun is equipped."
+		"tr_explain": "Twin Machinegun Stance Up Adds\nincreased S-ATK and R-ATK to\nstance skill effects when Twin\nMachineguns are equipped."
 	},
 	{
 		"assign": "91",

--- a/json/Explain_SkillRing.txt
+++ b/json/Explain_SkillRing.txt
@@ -249,7 +249,7 @@
 		"jp_text": "バレットボウホーミング",
 		"tr_text": "Bullet Bow Homing",
 		"jp_explain": "バレットボウホーミング\nバレットボウのチャージ通常攻撃に\n誘導性能が追加される。",
-		"tr_explain": "Bullet Bow Homing\nAdds a homing ability to a\nbullet bow's charged Normal Attack."
+		"tr_explain": "Bullet Bow Homing\nAdds a homing ability to a\nBullet Bow's charged Normal Attack."
 	},
 	{
 		"assign": "42",
@@ -270,7 +270,7 @@
 		"jp_text": "Ａランチャーモード",
 		"tr_text": "A. Launcher Mode",
 		"jp_explain": "アナザーランチャーモード\nランチャーの通常攻撃の弾道が変化し\n威力が上昇。攻撃範囲も広がる。",
-		"tr_explain": "Another Launcher Mode Changes the\ntrajectory and boosts the power of a\nlauncher's Normal Attack. Attack\nrange is also increased."
+		"tr_explain": "Another Launcher Mode Changes the\ntrajectory and boosts the power of a\nLauncher's Normal Attack. Attack\nrange is also increased."
 	},
 	{
 		"assign": "45",
@@ -508,7 +508,7 @@
 		"jp_text": "ＰＢホーミング",
 		"tr_text": "PB Homing",
 		"jp_explain": "フォトンブレードホーミング\n移動を伴うフォトンブレードの攻撃に\n誘導性能を追加する。",
-		"tr_explain": "Photon Blade Homing\nAdds a homing ability to\nphoton blade attacks."
+		"tr_explain": "Photon Blade Homing\nAdds a homing ability to\nPhoton Blade attacks."
 	},
 	{
 		"assign": "74",
@@ -606,7 +606,7 @@
 		"jp_text": "TマシンガンＳアップ",
 		"tr_text": "T. Machinegun S-Up",
 		"jp_explain": "ツインマシンガンスタンスアップ\nツインマシンガンを装備している間\nスタンススキルの効果に打撃・射撃威力上昇を追加。",
-		"tr_explain": "Twin Machinegun Stance Up Adds\nincreased S-ATK and R-ATK to\nstance skill effects when a twin\nmachinegun is equipped."
+		"tr_explain": "Twin Machinegun Stance Up Adds\nincreased S-ATK and R-ATK to\nstance skill effects when a Twin\nMachinegun is equipped."
 	},
 	{
 		"assign": "91",

--- a/json/Item_AvatarWPN_TwinMachineGun.txt
+++ b/json/Item_AvatarWPN_TwinMachineGun.txt
@@ -312,7 +312,7 @@
 		"jp_text": "＊フォルニスフィジス",
 		"tr_text": "＊Fornis Physis",
 		"jp_explain": "異なる力を宿す双機銃型武器迷彩。\n扱いは非常に難しいものの、卓越した\n威力を誇り、敵を圧倒できる。",
-		"tr_explain": "A twin machinegun camo bearing\ntwin powers. Difficult to handle, but\nits power overwhelms the enemy."
+		"tr_explain": "A Twin Machinegun camo bearing\ntwin powers. Difficult to handle, but\nits power overwhelms the enemy."
 	},
 	{
 		"assign": "1010046",
@@ -347,7 +347,7 @@
 		"jp_text": "＊アングスウィンディア",
 		"tr_text": "＊Angs Windea",
 		"jp_explain": "自然現象が形になったという双機銃型\n武器迷彩。吹き荒れる烈風が弾丸に\n込められ、瞬く間に標的を消し去る。",
-		"tr_explain": "A natural phenomenon that has taken\nthe form of a twin machinegun camo.\nShapes storm winds into bullets."
+		"tr_explain": "A natural phenomenon that has taken\nthe form of a Twin Machinegun camo.\nShapes storm winds into bullets."
 	},
 	{
 		"assign": "1010063",

--- a/json/Item_Costume_Female.txt
+++ b/json/Item_Costume_Female.txt
@@ -17728,42 +17728,42 @@
 		"jp_text": "ステラ・レプカ",
 		"tr_text": "Stella Repca",
 		"jp_explain": "白羊騎士団の当主を務めるステラが\n着用する服装。清楚さと優しさの中に\n当主たる威容も感じさせる。",
-		"tr_explain": "Clothing worn by Stella, head of\nthe Knights of Aries. Its neat, clean\nkindness gives a feeling of dignity."
+		"tr_explain": "Clothing worn by Stella, head of\nthe Aries Knights. Its neat, clean\nkindness gives a feeling of dignity."
 	},
 	{
 		"assign": "2202754",
 		"jp_text": "ステラ・レプカ紅",
 		"tr_text": "Stella Repca Crimson",
 		"jp_explain": "白羊騎士団の当主を務めるステラが\n着用する服装。清楚さと優しさの中に\n当主たる威容も感じさせる。",
-		"tr_explain": "Clothing worn by Stella, head of\nthe Knights of Aries. Its neat, clean\nkindness gives a feeling of dignity."
+		"tr_explain": "Clothing worn by Stella, head of\nthe Aries Knights. Its neat, clean\nkindness gives a feeling of dignity."
 	},
 	{
 		"assign": "2202755",
 		"jp_text": "ステラ・レプカ影",
 		"tr_text": "Stella Repca Shadow",
 		"jp_explain": "白羊騎士団の当主を務めるステラが\n着用する服装。清楚さと優しさの中に\n当主たる威容も感じさせる。",
-		"tr_explain": "Clothing worn by Stella, head of\nthe Knights of Aries. Its neat, clean\nkindness gives a feeling of dignity."
+		"tr_explain": "Clothing worn by Stella, head of\nthe Aries Knights. Its neat, clean\nkindness gives a feeling of dignity."
 	},
 	{
 		"assign": "2202756",
 		"jp_text": "ステラ・レプカ雅",
 		"tr_text": "Stella Repca Elegant",
 		"jp_explain": "白羊騎士団の当主を務めるステラが\n着用する服装。清楚さと優しさの中に\n当主たる威容も感じさせる。",
-		"tr_explain": "Clothing worn by Stella, head of\nthe Knights of Aries. Its neat, clean\nkindness gives a feeling of dignity."
+		"tr_explain": "Clothing worn by Stella, head of\nthe Aries Knights. Its neat, clean\nkindness gives a feeling of dignity."
 	},
 	{
 		"assign": "2202757",
 		"jp_text": "ステラ・レプカ葉",
 		"tr_text": "Stella Repca Leaf",
 		"jp_explain": "白羊騎士団の当主を務めるステラが\n着用する服装。清楚さと優しさの中に\n当主たる威容も感じさせる。",
-		"tr_explain": "Clothing worn by Stella, head of\nthe Knights of Aries. Its neat, clean\nkindness gives a feeling of dignity."
+		"tr_explain": "Clothing worn by Stella, head of\nthe Aries Knights. Its neat, clean\nkindness gives a feeling of dignity."
 	},
 	{
 		"assign": "2202758",
 		"jp_text": "ステラ・レプカ桜",
 		"tr_text": "Stella Repca Sakura",
 		"jp_explain": "白羊騎士団の当主を務めるステラが\n着用する服装。清楚さと優しさの中に\n当主たる威容も感じさせる。",
-		"tr_explain": "Clothing worn by Stella, head of\nthe Knights of Aries. Its neat, clean\nkindness gives a feeling of dignity."
+		"tr_explain": "Clothing worn by Stella, head of\nthe Aries Knights. Its neat, clean\nkindness gives a feeling of dignity."
 	},
 	{
 		"assign": "2202759",

--- a/json/Item_Costume_Male.txt
+++ b/json/Item_Costume_Male.txt
@@ -10238,42 +10238,42 @@
 		"jp_text": "ユリィＬ・レプカ",
 		"tr_text": "Uly L Repca",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nロウ班と行動を共にする際の服装。\n凛とした姿だが、包容力を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Law. Dignified yet welcoming."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Law. Dignified yet welcoming."
 	},
 	{
 		"assign": "2101633",
 		"jp_text": "ユリィＬ・レプカ影",
 		"tr_text": "Uly L Repca Shadow",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nロウ班と行動を共にする際の服装。\n凛とした姿だが、包容力を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Law. Dignified yet welcoming."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Law. Dignified yet welcoming."
 	},
 	{
 		"assign": "2101634",
 		"jp_text": "ユリィＬ・レプカ紅",
 		"tr_text": "Uly L Repca Crimson",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nロウ班と行動を共にする際の服装。\n凛とした姿だが、包容力を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Law. Dignified yet welcoming."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Law. Dignified yet welcoming."
 	},
 	{
 		"assign": "2101635",
 		"jp_text": "ユリィＬ・レプカ夜",
 		"tr_text": "Uly L Repca Night",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nロウ班と行動を共にする際の服装。\n凛とした姿だが、包容力を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Law. Dignified yet welcoming."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Law. Dignified yet welcoming."
 	},
 	{
 		"assign": "2101636",
 		"jp_text": "ユリィＬ・レプカ葉",
 		"tr_text": "Uly L Repca Leaf",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nロウ班と行動を共にする際の服装。\n凛とした姿だが、包容力を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Law. Dignified yet welcoming."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Law. Dignified yet welcoming."
 	},
 	{
 		"assign": "2101637",
 		"jp_text": "ユリィＬ・レプカ栗",
 		"tr_text": "Uly L Repca Chestnut",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nロウ班と行動を共にする際の服装。\n凛とした姿だが、包容力を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Law. Dignified yet welcoming."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Law. Dignified yet welcoming."
 	},
 	{
 		"assign": "2101638",
@@ -10420,42 +10420,42 @@
 		"jp_text": "ユリィＣ・レプカ",
 		"tr_text": "Uly C Repca",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nカオス班と行動を共にする際の服装。\n強い覚悟と意志を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Chaos. Houses a strong will."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Chaos. Houses a strong will."
 	},
 	{
 		"assign": "2101661",
 		"jp_text": "ユリィＣ・レプカ紅",
 		"tr_text": "Uly C Repca Crimson",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nカオス班と行動を共にする際の服装。\n強い覚悟と意志を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Chaos. Houses a strong will."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Chaos. Houses a strong will."
 	},
 	{
 		"assign": "2101662",
 		"jp_text": "ユリィＣ・レプカ海",
 		"tr_text": "Uly C Repca Sea",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nカオス班と行動を共にする際の服装。\n強い覚悟と意志を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Chaos. Houses a strong will."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Chaos. Houses a strong will."
 	},
 	{
 		"assign": "2101663",
 		"jp_text": "ユリィＣ・レプカ雅",
 		"tr_text": "Uly C Repca Elegant",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nカオス班と行動を共にする際の服装。\n強い覚悟と意志を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Chaos. Houses a strong will."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Chaos. Houses a strong will."
 	},
 	{
 		"assign": "2101664",
 		"jp_text": "ユリィＣ・レプカ雪",
 		"tr_text": "Uly C Repca Snow",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nカオス班と行動を共にする際の服装。\n強い覚悟と意志を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Chaos. Houses a strong will."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Chaos. Houses a strong will."
 	},
 	{
 		"assign": "2101665",
 		"jp_text": "ユリィＣ・レプカ栗",
 		"tr_text": "Uly C Repca Chestnut",
 		"jp_explain": "白羊騎士団の遊撃隊隊長ユリィが\nカオス班と行動を共にする際の服装。\n強い覚悟と意志を感じさせる。",
-		"tr_explain": "Suit worn by Uly, captain of the Aries\nWhite Knights, when he fights on the\nside of Chaos. Houses a strong will."
+		"tr_explain": "Suit worn by Uly, captain of the Aries\nKnights, when he fights on the\nside of Chaos. Houses a strong will."
 	},
 	{
 		"assign": "2101667",

--- a/json/Item_NGS_CapsuleAbilities.txt
+++ b/json/Item_NGS_CapsuleAbilities.txt
@@ -537,5 +537,12 @@
 		"jp_explain": "特殊能力“ギガス・テクニックⅡ”を<br>武器、防具に追加するカプセル。",
 		"tr_explain": "A capsule that adds the Special Ability\n\"Gigas Technique II\"\nto weapons and armor.",
 		"assign": 0
+	},
+	{
+		"jp_text": "C/サンダーウィーカーⅠ",
+		"tr_text": "C/Thunder Weaker I",
+		"jp_explain": "特殊能力“サンダーウィーカーⅠ”を<br>武器、防具に追加するカプセル。",
+		"tr_explain": "A capsule that adds the Special Ability\n\"Thunder Weaker I\"\nto weapons and armor.",
+		"assign": 0
 	}
 ]

--- a/json/Item_Pet_CandyParfait.txt
+++ b/json/Item_Pet_CandyParfait.txt
@@ -74,35 +74,35 @@
 		"jp_text": "はりきりパフェ",
 		"tr_text": "Spirited Parfait",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks by 40%."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks by 40%."
 	},
 	{
 		"assign": "338011",
 		"jp_text": "はりきりパフェ＋１",
 		"tr_text": "Spirited Parfait+1",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks by 40%."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks by 40%."
 	},
 	{
 		"assign": "338012",
 		"jp_text": "はりきりパフェ＋２",
 		"tr_text": "Spirited Parfait+2",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks by 40%."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks by 40%."
 	},
 	{
 		"assign": "338013",
 		"jp_text": "はりきりパフェ＋３",
 		"tr_text": "Spirited Parfait+3",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks by 40%."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks by 40%."
 	},
 	{
 		"assign": "338014",
 		"jp_text": "はりきりパフェ＋４",
 		"tr_text": "Spirited Parfait+4",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks by 40%."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks by 40%."
 	},
 	{
 		"assign": "338015",
@@ -1719,35 +1719,35 @@
 		"jp_text": "超はりきりパフェ",
 		"tr_text": "Super Spirited Parfait",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks."
 	},
 	{
 		"assign": "3380301",
 		"jp_text": "超はりきりパフェ＋１",
 		"tr_text": "Super Spirited Parfait+1",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks."
 	},
 	{
 		"assign": "3380302",
 		"jp_text": "超はりきりパフェ＋２",
 		"tr_text": "Super Spirited Parfait+2",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks."
 	},
 	{
 		"assign": "3380303",
 		"jp_text": "超はりきりパフェ＋３",
 		"tr_text": "Super Spirited Parfait+3",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks."
 	},
 	{
 		"assign": "3380304",
 		"jp_text": "超はりきりパフェ＋４",
 		"tr_text": "Super Spirited Parfait+4",
 		"jp_explain": "ペット用のキャンディー。\nペットの通常攻撃の\nダメージが上昇する。",
-		"tr_explain": "A Candy for your pet.\nBoosts damage of pet normal\nattacks."
+		"tr_explain": "A Candy for your pet.\nBoosts damage of pet Normal\nAttacks."
 	},
 	{
 		"assign": "3380305",

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -73215,9 +73215,9 @@
 	{
 		"assign": "38010039",
 		"jp_text": "トゥインクルリボン",
-		"tr_text": "",
+		"tr_text": "Twinkle Ribbon",
 		"jp_explain": "使用すると新しいアクセサリーが\n選択可能になる。",
-		"tr_explain": ""
+		"tr_explain": "Unlocks the accessory\n\"Twinkle Ribbon\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "38010040",

--- a/json/Item_Stack_Boost.txt
+++ b/json/Item_Stack_Boost.txt
@@ -802,7 +802,7 @@
 		"jp_text": "イドラ風ステーキ",
 		"tr_text": "Idola-style Steak",
 		"jp_explain": "アスタル亭で提供される名物料理。\n【５分間】打・射・法撃力＋１５０\n獲得経験値＋１５０％",
-		"tr_explain": "Astal House specialty steak.\n[5 min] ATK +150 EXP +150%."
+		"tr_explain": "Astarte Tavern specialty steak.\n[5 min] ATK +150 EXP +150%."
 	},
 	{
 		"assign": "320147",

--- a/json/Item_Stack_GatBoost.txt
+++ b/json/Item_Stack_GatBoost.txt
@@ -95,21 +95,21 @@
 		"jp_text": "ジャーキー",
 		"tr_text": "Jerky",
 		"jp_explain": "薄くスライスした肉を干した料理。\n【３０分間】ＨＰ＋５０、ＰＰ＋５\n<yellow>同種の料理は効果が上書きされます。<c>",
-		"tr_explain": "Thinly sliced dried meat.\n[30 min] HP+50 PP+5\n<yellow>Same dish will overwrite the effect.<c>"
+		"tr_explain": "Thinly sliced dried meat.\n[30 min] HP +50 PP +5\n<yellow>Same dish will overwrite the effect.<c>"
 	},
 	{
 		"assign": "350017",
 		"jp_text": "肉野菜炒め",
 		"tr_text": "Meat Stir Fry",
 		"jp_explain": "高熱でしっかり炒められた料理。\n【３０分間】打射法撃力＋１００、ＨＰ＋５０\n<yellow>同種の料理は効果が上書きされます。<c>",
-		"tr_explain": "Robust high-heat cooked meat dish.\n[30 min] ATK+100 HP+50\n<yellow>Same dish will overwrite the effect.<c>"
+		"tr_explain": "Robust high-heat cooked meat dish.\n[30 min] ATK +100 HP +50\n<yellow>Same dish will overwrite the effect.<c>"
 	},
 	{
 		"assign": "350018",
 		"jp_text": "マリネ",
 		"tr_text": "Marinade",
 		"jp_explain": "揚げた肉を酢と油に漬けた料理。\n【３０分間】打射法防御＋１００、ＰＰ＋５\n<yellow>同種の料理は効果が上書きされます。<c>",
-		"tr_explain": "Fried meat soaked in vinegar and oil.\n[30 min] DEF+100 PP+5\n<yellow>Same dish will overwrite the effect.<c>"
+		"tr_explain": "Fried meat soaked in vinegar and oil.\n[30 min] DEF +100 PP +5\n<yellow>Same dish will overwrite the effect.<c>"
 	},
 	{
 		"assign": "350019",

--- a/json/Item_Stack_GatFMatShellfish.txt
+++ b/json/Item_Stack_GatFMatShellfish.txt
@@ -74,27 +74,27 @@
 		"jp_text": "マッタ・エアルアザーリ",
 		"tr_text": "Nourishing Aerio Clam",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\nPP消費量軽減",
-		"tr_explain": "Shellfish caught in Aerio.\nIncreases HP and\nreduces PP consumption."
+		"tr_explain": "Seafood caught in Aerio.\nIncreases HP and\nreduces PP consumption."
 	},
 	{
 		"assign": "363010003",
 		"jp_text": "サッパ・エアルサザイエ",
 		"tr_text": "Refreshing Aerio Snail",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\nPP回復量増加",
-		"tr_explain": "Shellfish caught in Aerio.\nIncreases HP and\nincreases PP recovery."
+		"tr_explain": "Seafood caught in Aerio.\nIncreases HP and\nincreases PP recovery."
 	},
 	{
 		"assign": "363010004",
 		"jp_text": "シャッキ・エアルクラーブ",
 		"tr_text": "Sharp Aerio Crab",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\n弱点部位ダメージ増加",
-		"tr_explain": "Shellfish caught in Aerio.\nIncreases HP and\nboosts weakness damage."
+		"tr_explain": "Seafood caught in Aerio.\nIncreases HP and\nboosts weakness damage."
 	},
 	{
 		"assign": "363010005",
 		"jp_text": "ガッツ・エアルローブス",
 		"tr_text": "Healthy Aerio Lobster",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\nHP回復量増加",
-		"tr_explain": "Shellfish caught in Aerio.\nIncreases HP and\nboosts HP recovery."
+		"tr_explain": "Seafood caught in Aerio.\nIncreases HP and\nboosts HP recovery."
 	}
 ]

--- a/json/Item_Stack_PaidTicket.txt
+++ b/json/Item_Stack_PaidTicket.txt
@@ -65,65 +65,65 @@
 	{
 		"assign": "320010",
 		"jp_text": "拡張倉庫１利用３０日",
-		"tr_text": "Extended Storage 1 30 Days",
+		"tr_text": "Expansion Storage 1 30 Days",
 		"jp_explain": "拡張倉庫１の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫１が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n1 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n1 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320011",
 		"jp_text": "拡張倉庫１利用６０日",
-		"tr_text": "Extended Storage 1 60 Days",
+		"tr_text": "Expansion Storage 1 60 Days",
 		"jp_explain": "拡張倉庫１の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫１が６０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n1 for 60 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n1 for 60 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320012",
 		"jp_text": "拡張倉庫１利用９０日",
-		"tr_text": "Extended Storage 1 90 Days",
+		"tr_text": "Expansion Storage 1 90 Days",
 		"jp_explain": "拡張倉庫１の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫１が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n1 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n1 for 90 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320013",
 		"jp_text": "拡張倉庫２利用３０日",
-		"tr_text": "Extended Storage 2 30 Days",
+		"tr_text": "Expansion Storage 2 30 Days",
 		"jp_explain": "拡張倉庫２の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫２が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n2 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n2 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320014",
 		"jp_text": "拡張倉庫２利用６０日",
-		"tr_text": "Extended Storage 2 60 Days",
+		"tr_text": "Expansion Storage 2 60 Days",
 		"jp_explain": "拡張倉庫２の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫２が６０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n2 for 60 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n2 for 60 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320015",
 		"jp_text": "拡張倉庫２利用９０日",
-		"tr_text": "Extended Storage 2 90 Days",
+		"tr_text": "Expansion Storage 2 90 Days",
 		"jp_explain": "拡張倉庫２の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫２が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n2 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n2 for 90 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320016",
 		"jp_text": "拡張倉庫３利用３０日",
-		"tr_text": "Extended Storage 3 30 Days",
+		"tr_text": "Expansion Storage 3 30 Days",
 		"jp_explain": "拡張倉庫３の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫３が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n3 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n3 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320017",
 		"jp_text": "拡張倉庫３利用６０日",
-		"tr_text": "Extended Storage 3 60 Days",
+		"tr_text": "Expansion Storage 3 60 Days",
 		"jp_explain": "拡張倉庫３の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫３が６０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n3 for 60 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n3 for 60 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320018",
 		"jp_text": "拡張倉庫３利用９０日",
-		"tr_text": "Extended Storage 3 90 Days",
+		"tr_text": "Expansion Storage 3 90 Days",
 		"jp_explain": "拡張倉庫３の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫３が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n3 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n3 for 90 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320019",
@@ -205,7 +205,7 @@
 	{
 		"assign": "320030",
 		"jp_text": "サブパレット拡張チケット",
-		"tr_text": "Subpalette Expansion Ticket",
+		"tr_text": "Subpalette Extension Ticket",
 		"jp_explain": "サブパレットを拡張するチケット。\n１キャラクターにつき１個まで使用可能で\nブック０３～ブック０６が追加される。",
 		"tr_explain": "Ticket to extend your subpalette.\nUnlocks books 3 to 6 and can\nonly be used once per character."
 	},
@@ -583,30 +583,30 @@
 	{
 		"assign": "320087",
 		"jp_text": "拡張倉庫４利用３０日",
-		"tr_text": "Extended Storage 4 30 Days",
+		"tr_text": "Expansion Storage 4 30 Days",
 		"jp_explain": "拡張倉庫４の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫４が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n4 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n4 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320088",
 		"jp_text": "拡張倉庫４利用９０日",
-		"tr_text": "Extended Storage 4 90 Days",
+		"tr_text": "Expansion Storage 4 90 Days",
 		"jp_explain": "拡張倉庫４の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫４が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n4 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n4 for 90 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320089",
 		"jp_text": "拡張倉庫５利用３０日",
-		"tr_text": "Extended Storage 5 30 Days",
+		"tr_text": "Expansion Storage 5 30 Days",
 		"jp_explain": "拡張倉庫５の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫５が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n5 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n5 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320090",
 		"jp_text": "拡張倉庫５利用９０日",
-		"tr_text": "Extended Storage 5 90 Days",
+		"tr_text": "Expansion Storage 5 90 Days",
 		"jp_explain": "拡張倉庫５の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫５が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n5 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n5 for 90 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "320094",
@@ -1234,16 +1234,16 @@
 	{
 		"assign": "3200188",
 		"jp_text": "拡張倉庫１利用３０日Ｓ",
-		"tr_text": "Extended Storage 1 30 Days S",
+		"tr_text": "Expansion Storage 1 30 Days S",
 		"jp_explain": "拡張倉庫１の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫１が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n1 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n1 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "3200189",
 		"jp_text": "拡張倉庫１利用９０日Ｓ",
-		"tr_text": "Extended Storage 1 90 Days S",
+		"tr_text": "Expansion Storage 1 90 Days S",
 		"jp_explain": "拡張倉庫１の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫１が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n1 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n1 for 90 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "3200190",
@@ -1360,15 +1360,15 @@
 	{
 		"assign": "3200287",
 		"jp_text": "拡張倉庫６利用３０日",
-		"tr_text": "Extended Storage 6 30 Days",
+		"tr_text": "Expansion Storage 6 30 Days",
 		"jp_explain": "拡張倉庫６の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫６が３０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n6 for 30 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n6 for 30 days. You can still retrieve\nitems after it expires."
 	},
 	{
 		"assign": "3200288",
 		"jp_text": "拡張倉庫６利用９０日",
-		"tr_text": "Extended Storage 6 90 Days",
+		"tr_text": "Expansion Storage 6 90 Days",
 		"jp_explain": "拡張倉庫６の利用許可チケット。\n使用するとアイテム５００個を格納する\n拡張倉庫６が９０日間利用可能になる。",
-		"tr_explain": "Allows access to Extended Storage\n6 for 90 days. You can still retrieve\nitems after it expires."
+		"tr_explain": "Allows access to Expansion Storage\n6 for 90 days. You can still retrieve\nitems after it expires."
 	}
 ]

--- a/json/Item_Stack_Sticker.txt
+++ b/json/Item_Stack_Sticker.txt
@@ -5238,9 +5238,9 @@
 	{
 		"assign": "3170404",
 		"jp_text": "ＰＷ×リリーパ族",
-		"tr_text": "PW x Lillipans",
+		"tr_text": "PW x Lillipan",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nＰＷ×リリーパ族が選択可能。",
-		"tr_explain": "Unlocks the sticker\n\"PW x Lillipans\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the sticker\n\"PW x Lillipan\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "317020404",
@@ -5252,9 +5252,9 @@
 	{
 		"assign": "3170405",
 		"jp_text": "ＰＷ×アークマ",
-		"tr_text": "PW x ARKS",
+		"tr_text": "PW x Arkuma",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\nＰＷ×アークマが選択可能。",
-		"tr_explain": "Unlocks the sticker\n\"PW x ARKS\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the sticker\n\"PW x Arkuma\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "317020405",

--- a/json/Item_Stack_Sticker.txt
+++ b/json/Item_Stack_Sticker.txt
@@ -4734,9 +4734,9 @@
 	{
 		"assign": "3170367",
 		"jp_text": "白羊騎士団ステッカー",
-		"tr_text": "Aries White Knight Sticker",
+		"tr_text": "Aries Knights Sticker",
 		"jp_explain": "特定ステッカーの装着許可チケット。\n使用すると、新しいステッカーの\n白羊騎士団が選択可能。",
-		"tr_explain": "Unlocks the sticker\n\"Aries White Knight\"\nfor use in the Beauty Salon."
+		"tr_explain": "Unlocks the sticker\n\"Aries Knights\"\nfor use in the Beauty Salon."
 	},
 	{
 		"assign": "317020367",

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -486,7 +486,7 @@
 		"jp_text": "ダブルセイバーギア",
 		"tr_text": "Double Saber Gear",
 		"jp_explain": "",
-		"tr_explain": "Accumulate gear with attacks, then\nuse the weapon action to unleash a\ndamaging wind based on gear level.",
+		"tr_explain": "Accumulate gear with attacks, then\nuse the Weapon Action to unleash a\ndamaging wind based on gear level.",
 		"assign": 0
 	},
 	{

--- a/json/Items_Leftovers.txt
+++ b/json/Items_Leftovers.txt
@@ -45,7 +45,7 @@
 		"jp_text": "アタックＰＰリストレイト",
 		"tr_text": "Attack PP Restorate",
 		"jp_explain": "",
-		"tr_explain": "Boosts the amount of PP recovered\nwhen hitting with normal attacks.",
+		"tr_explain": "Boosts the amount of PP recovered\nwhen hitting with Normal Attacks.",
 		"assign": 0
 	},
 	{
@@ -150,7 +150,7 @@
 		"jp_text": "ウォンドギア",
 		"tr_text": "Wand Gear",
 		"jp_explain": "",
-		"tr_explain": "Accumulates gear when hitting\nenemies with charged Techniques,\nand causes normal attacks to\ngenerate a Tech explosion.",
+		"tr_explain": "Accumulates gear when hitting\nenemies with charged Techniques,\nand causes Normal Attacks to\ngenerate a Tech explosion.",
 		"assign": 0
 	},
 	{
@@ -353,7 +353,7 @@
 		"jp_text": "ジェットブーツエスケープ",
 		"tr_text": "Jet Boots Escape",
 		"jp_explain": "",
-		"tr_explain": "When using Jet Boots, makes you\ninvincible during PA and normal attack\nShift Actions.",
+		"tr_explain": "When using Jet Boots, makes you\ninvincible during PA and Normal Attack\nShift Actions.",
 		"assign": 0
 	},
 	{
@@ -507,7 +507,7 @@
 		"jp_text": "チェイントリガー",
 		"tr_text": "Chain Trigger",
 		"jp_explain": "",
-		"tr_explain": "After invoking the skill, normal attack\nhits will begin a Chain.",
+		"tr_explain": "After invoking the skill, Normal Attack\nhits will begin a Chain.",
 		"assign": 0
 	},
 	{
@@ -563,7 +563,7 @@
 		"jp_text": "デバンドアタックＰＰＲ",
 		"tr_text": "Deband Attack PP Restorate",
 		"jp_explain": "",
-		"tr_explain": "During Deband's effect, increase PP\nrecovery from normal attacks.",
+		"tr_explain": "During Deband's effect, increase PP\nrecovery from Normal Attacks.",
 		"assign": 0
 	},
 	{
@@ -801,14 +801,14 @@
 		"jp_text": "ラピッドシュート",
 		"tr_text": "Rapid Shot",
 		"jp_explain": "",
-		"tr_explain": "A Bullet Bow skill. For a limited time,\nsacrifices the bow's normal attack\npower and rate of fire for a three-shot\nnormal attack.",
+		"tr_explain": "A Bullet Bow skill. For a limited time,\nsacrifices the bow's Normal Attack\npower and rate of fire for a three-shot\nNormal Attack.",
 		"assign": 0
 	},
 	{
 		"jp_text": "ラピッドシュートアドバンス",
 		"tr_text": "Rapid Shot Advance",
 		"jp_explain": "",
-		"tr_explain": "Reduces the cooldown of Rapid Shot,\nand increases the PP recovery from\nnormal attacks while it is active.",
+		"tr_explain": "Reduces the cooldown of Rapid Shot,\nand increases the PP recovery from\nNormal Attacks while it is active.",
 		"assign": 0
 	},
 	{
@@ -2110,7 +2110,7 @@
 		"jp_text": "アタックアドバンス",
 		"tr_text": "Attack Advance",
 		"jp_explain": "",
-		"tr_explain": "Increase damage for normal attacks.",
+		"tr_explain": "Increase damage for Normal Attacks.",
 		"assign": 0
 	},
 	{

--- a/json/Title_All.txt
+++ b/json/Title_All.txt
@@ -12477,19 +12477,19 @@
 		"assign": "700300000",
 		"jp_text": "ギャザリングフィーバー",
 		"tr_text": "Gathering Fever",
-		"tr_explain": "Trigger a Fever while gathering once"
+		"tr_explain": "Trigger a Fever while Gathering once"
 	},
 	{
 		"assign": "700300001",
 		"jp_text": "スーパーＧフィーバー",
 		"tr_text": "Super G Fever",
-		"tr_explain": "Trigger a Fever while gathering 10 times"
+		"tr_explain": "Trigger a Fever while Gathering 10 times"
 	},
 	{
 		"assign": "700300002",
 		"jp_text": "スターＧフィーバー",
 		"tr_text": "Star G Fever",
-		"tr_explain": "Trigger a Fever while gathering 100 times"
+		"tr_explain": "Trigger a Fever while Gathering 100 times"
 	},
 	{
 		"assign": "700600000",

--- a/json/TowerQuest_BlockSettingText.txt
+++ b/json/TowerQuest_BlockSettingText.txt
@@ -9,7 +9,7 @@
 	},
 	{
 		"jp_text": "<color=red>▼</color>通常攻撃のダメージが <%parameter1%>％に",
-		"tr_text": "<color=red>▼</color>Normal attack damage -<%parameter1%>%"
+		"tr_text": "<color=red>▼</color>Normal Attack damage -<%parameter1%>%"
 	},
 	{
 		"jp_text": "<color=red>▼</color>ダメージ上限が <%parameter1%>に",

--- a/json/UI_QuestTips.txt
+++ b/json/UI_QuestTips.txt
@@ -27,7 +27,7 @@
 	{
 		"assign": "0005",
 		"jp_text": "<color=#f0df60>＜ＣＰを回復するテクニック＞</color>\nＣＰは時間とともに少しずつ増えていきますが\nエネミーに攻撃を命中させると、さらに増えるんです。\nＣＰをためて、チップをどんどん発動させましょう。",
-		"tr_text": "<color=#f0df60>CP Recovery Techniques</color>\nCP regenerates slowly over time, but if you hit an\nenemy with a normal attack, you will recover some\nCP immediately. Recover your CP and activate chips!"
+		"tr_text": "<color=#f0df60>CP Recovery Techniques</color>\nCP regenerates slowly over time, but if you hit an\nenemy with a Normal Attack, you will recover some\nCP immediately. Recover your CP and activate chips!"
 	},
 	{
 		"assign": "0006",
@@ -177,7 +177,7 @@
 	{
 		"assign": "0035",
 		"jp_text": "<color=#f0df60>＜チップでもジャストアタック＞</color>\nジャストアタックは、通常攻撃だけでなく\nアクティブチップでも発動することができますよ。\nチップを使うときに、赤い円にタイミングをあわせて\n発動してみましょう。",
-		"tr_text": "<color=#f0df60>Just Attacking Chips</color>\nJust Attacks don't just apply to normal attacks -\nyou can do them with Active Chips too! Try to\ntime your chip activations to the red circle."
+		"tr_text": "<color=#f0df60>Just Attacking Chips</color>\nJust Attacks don't just apply to Normal Attacks -\nyou can do them with Active Chips too! Try to\ntime your chip activations to the red circle."
 	},
 	{
 		"assign": "0036",
@@ -1182,7 +1182,7 @@
 	{
 		"assign": "0236",
 		"jp_text": "<color=#f0df60>＜プレイヤーに特殊な制限が発生＞</color>\nこのブロックでは「通常攻撃耐性」「ダメージ上限」\nなどプレイヤーに様々な制限が発動します。\n臨機応変に対応できるよう\n十分に準備を整え挑んでください！",
-		"tr_text": "<color=#f0df60>Special Player Restrictions</color>\nIn this block, you will be affected by a special\nrestriction, such as \"Normal attack damage\nresistance\" or \"Maximum limit on damage\".\nEquip yourself in a way that lets you respond\nflexibly to whatever comes your way!"
+		"tr_text": "<color=#f0df60>Special Player Restrictions</color>\nIn this block, you will be affected by a special\nrestriction, such as \"Normal Attack damage\nresistance\" or \"Maximum limit on damage\".\nEquip yourself in a way that lets you respond\nflexibly to whatever comes your way!"
 	},
 	{
 		"assign": "0237",
@@ -1307,7 +1307,7 @@
 	{
 		"assign": "0261",
 		"jp_text": "<color=#f0df60>＜プレイヤーに特殊な制限が発生＞</color>\nこのブロックでは「通常攻撃で与えるダメージが減少」\nします。通常攻撃ではエネミーを倒しづらいでしょう。\n必殺技や法術など、様々な攻撃方法を駆使して\nエネミーに立ち向かってください！",
-		"tr_text": "<color=#f0df60>Special Restrictions on Players</color>\nIn this block, damage dealt by normal\nattacks is reduced. Try using special\nattacks like PAs and Techniques to\ndefeat enemies!"
+		"tr_text": "<color=#f0df60>Special Restrictions on Players</color>\nIn this block, damage dealt by Normal\nAttacks is reduced. Try using special\nattacks like PAs and Techniques to\ndefeat enemies!"
 	},
 	{
 		"assign": "0262",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -10772,7 +10772,7 @@
 	{
 		"assign": "chip_pack_expand",
 		"jp_text": "チップパック拡張",
-		"tr_text": "Chip Expansion Pack"
+		"tr_text": "Chip Pack Expansion"
 	},
 	{
 		"assign": "chip_grind",

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -2487,7 +2487,7 @@
 	{
 		"assign": "item_grind_guide_03",
 		"jp_text": "<color=#f0df60>これ以上強化をするためには潜在能力の解放が必要です。解放したい潜在能力を選択してください。</color>",
-		"tr_text": "<color=#f0df60>Before you can upgrade this weapon any further, you must unlock its potential. Please select a potential to unlock.</color>"
+		"tr_text": "<color=#f0df60>Before you can upgrade this weapon any further, you must unlock its Potential. Please select a Potential to unlock.</color>"
 	},
 	{
 		"assign": "labo_dialog_t_09",
@@ -2702,7 +2702,7 @@
 	{
 		"assign": "labo_dialog_b_22",
 		"jp_text": "特殊能力追加が完了しました。",
-		"tr_text": "Special ability addition complete."
+		"tr_text": "Special Ability addition complete."
 	},
 	{
 		"assign": "labo_guide_15",
@@ -3762,7 +3762,7 @@
 	{
 		"assign": "myshop_dialog_b_07",
 		"jp_text": "存在しないアイテム、\nもしくは特殊能力名を指定しています。\n\n<color=#ff0000>※アイテム名、特殊能力名は\n完全一致のみ検索にヒットします。</color>",
-		"tr_text": "You have specified an item or special ability\nthat does not exist.\n\n<color=#ff0000>※When searching for items or special abilities,\nonly exact matches will be found.</color>"
+		"tr_text": "You have specified an item or Special Ability\nthat does not exist.\n\n<color=#ff0000>※When searching for items or Special Abilities,\nonly exact matches will be found.</color>"
 	},
 	{
 		"assign": "myshop_dialog_t_08",
@@ -22337,7 +22337,7 @@
 	{
 		"assign": "weapon_potential_awake_message",
 		"jp_text": "選択した潜在能力を解放します。\nよろしいですか？",
-		"tr_text": "You will unlock the selected potential.\nContinue?"
+		"tr_text": "You will unlock the selected Potential.\nContinue?"
 	},
 	{
 		"assign": "weapon_potential_awake_confirm_dialog_title",
@@ -22347,7 +22347,7 @@
 	{
 		"assign": "weapon_potential_awake_confirm_dialog_message",
 		"jp_text": "潜在能力解放を開始します。\nよろしいですか？",
-		"tr_text": "Now unlocking potential.\nContinue?"
+		"tr_text": "Now unlocking Potential.\nContinue?"
 	},
 	{
 		"assign": "weapon_potential_awake_not_enough_item_dialog_title",
@@ -22357,7 +22357,7 @@
 	{
 		"assign": "weapon_potential_awake_not_enough_item_dialog_message",
 		"jp_text": "必要アイテムが不足しているため\n潜在能力解放できません。",
-		"tr_text": "Insufficient items to unlock potential."
+		"tr_text": "Insufficient items to unlock Potential."
 	},
 	{
 		"assign": "weapon_potential_awake_successed_dialog_title",
@@ -22397,7 +22397,7 @@
 	{
 		"assign": "gamma_weapon_grind_dialog_max_message",
 		"jp_text": "アイテム強化によって、強化値の+10 +20 +30の\nいずれかの上限に達しました。\n\nさらに強化するために、次回アイテム強化時は\n<color=yellow>自動的に「潜在能力解放」に進みます。</color>\n\n※潜在能力解放には、フォトンドロップや\nフォトンスフィアなどのアイテムが必要です。",
-		"tr_text": "Grinding the item has raised\nit to +10, +20 or +30.\n\nIn order to strengthen it further, you must\n<color=yellow>unlock its potential</color>, which you will do next\ntime you attempt to grind the item.\n\n※To unlock potentials, you need special\nitems such as Photon Drops."
+		"tr_text": "Grinding the item has raised\nit to +10, +20 or +30.\n\nIn order to strengthen it further, you must\n<color=yellow>unlock its Potential</color>, which you will do next\ntime you attempt to grind the item.\n\n※To unlock Potentials, you need special\nitems such as Photon Drops."
 	},
 	{
 		"assign": "gamma_weapon_grind_dialog_caution",


### PR DESCRIPTION
Fix Normal Attack/Special Ability/Abilities/Potential/Chain Count/Weapon Action/Weapon/Gathering terms.
Fix Idola terms.
Add Thunder Weaker I capsule.
Translate an event shop accessory.
Fix some consumables.
Fix gathering items to match Regional Mag boost description.
Fix Expansion Storage term.
Fix Subpalette Extension term.
Fix PW stickers.
Fix Chip Pack Expansion term.