### PR TITLE
PSO2es EN: Sept 20th Hotfixes

### DIFF
--- a/json/Item_NGS_Motion.txt
+++ b/json/Item_NGS_Motion.txt
@@ -201,5 +201,12 @@
 		"jp_explain": "",
 		"tr_explain": "A motion that unlocks for all\ncharacters on your account.\n<yellow>※Cannot perform in [PSO2] Blocks.<c>",
 		"assign": 0
+	},
+	{
+		"jp_text": "Mo「ダッシュ：ニンジャ」",
+		"tr_text": "Mo \"Dash: Ninja\"",
+		"jp_explain": "",
+		"tr_explain": "A motion that unlocks for all\ncharacters on your account.\n<yellow>※Cannot perform in [PSO2] Blocks.<c>",
+		"assign": 0
 	}
 ]

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -74111,14 +74111,14 @@
 	{
 		"assign": "38010173",
 		"jp_text": "アームカノーネ/B",
-		"tr_text": "Arm Cannonne /B",
+		"tr_text": "Arm Cannonne/B",
 		"jp_explain": "使用すると新しいアクセサリーが\n選択可能になる。",
 		"tr_explain": "Unlocks a new accessory for use."
 	},
 	{
 		"assign": "38010174",
 		"jp_text": "シュネールウィーゼル/B",
-		"tr_text": "Schnell Wiesel /B",
+		"tr_text": "Schnell Wiesel/B",
 		"jp_explain": "使用すると新しいアクセサリーが\n選択可能になる。",
 		"tr_explain": "Unlocks a new accessory for use."
 	},

--- a/json/Item_Stack_Accessory.txt
+++ b/json/Item_Stack_Accessory.txt
@@ -73985,7 +73985,7 @@
 	{
 		"assign": "38010155",
 		"jp_text": "スティリアヘッドギア",
-		"tr_text": "Sylia Headgear",
+		"tr_text": "Stylia Headgear",
 		"jp_explain": "使用すると新しいアクセサリーが\n選択可能になる。",
 		"tr_explain": "Unlocks a new accessory for use."
 	},

--- a/json/Item_Stack_BodyPaint.txt
+++ b/json/Item_Stack_BodyPaint.txt
@@ -11195,7 +11195,7 @@
 	{
 		"assign": "329010062",
 		"jp_text": "ワソウタビィ/B",
-		"tr_text": "Wasou Tabi /B",
+		"tr_text": "Wasou Tabi/B",
 		"jp_explain": "使用すると新しいボディペイントが\n選択可能になる。",
 		"tr_explain": "Unlocks a new body paint for use."
 	},
@@ -11209,7 +11209,7 @@
 	{
 		"assign": "329010065",
 		"jp_text": "ワソウテブク＆タビィ/B",
-		"tr_text": "Wasou Gloves & Tabi /B",
+		"tr_text": "Wasou Gloves & Tabi/B",
 		"jp_explain": "使用すると新しいボディペイントが\n選択可能になる。",
 		"tr_explain": "Unlocks a new body paint for use."
 	},
@@ -11223,7 +11223,7 @@
 	{
 		"assign": "329010067",
 		"jp_text": "N-ゲンショウタイツT1/B",
-		"tr_text": "N-Genshou Tights T1 /B",
+		"tr_text": "N-Genshou Tights T1/B",
 		"jp_explain": "使用すると新しいボディペイントが\n選択可能になる。\n<yellow>※対応：ヒト型/キャストタイプ1<c>",
 		"tr_explain": "Unlocks a new body paint for use.\n<yellow>※Type: Human/Cast Type 1<c>"
 	},
@@ -11237,7 +11237,7 @@
 	{
 		"assign": "329010069",
 		"jp_text": "N-ゲンショウタイツT2/B",
-		"tr_text": "N-Genshou Tights T2 /B",
+		"tr_text": "N-Genshou Tights T2/B",
 		"jp_explain": "使用すると新しいボディペイントが\n選択可能になる。\n<yellow>※対応：ヒト型/キャストタイプ2<c>",
 		"tr_explain": "Unlocks a new body paint for use.\n<yellow>※Type: Human/Cast Type 2<c>"
 	},
@@ -11251,7 +11251,7 @@
 	{
 		"assign": "329010071",
 		"jp_text": "スティルクグローブ/B",
-		"tr_text": "Stylk Gloves /B",
+		"tr_text": "Stylk Gloves/B",
 		"jp_explain": "使用すると新しいボディペイントが\n選択可能になる。",
 		"tr_explain": "Unlocks a new body paint for use."
 	},
@@ -11265,7 +11265,7 @@
 	{
 		"assign": "329010073",
 		"jp_text": "ユメハナタトゥー/B",
-		"tr_text": "Yumehana Tattoo /B",
+		"tr_text": "Yumehana Tattoo/B",
 		"jp_explain": "使用すると新しいボディペイントが\n選択可能になる。\n<yellow>※対応：ヒト型/キャストタイプ2<c>",
 		"tr_explain": "Unlocks a new body paint for use.\n<yellow>※Type: Human/Cast Type 2<c>"
 	},

--- a/json/Item_Stack_Eye.txt
+++ b/json/Item_Stack_Eye.txt
@@ -3866,7 +3866,7 @@
 	{
 		"assign": "326010021",
 		"jp_text": "ルシオーラアイ/B",
-		"tr_text": "Luxiora Eyes /B",
+		"tr_text": "Luxiora Eyes/B",
 		"jp_explain": "使用すると新しい瞳パターンが\n選択可能になる。",
 		"tr_explain": "Unlocks a new eye pattern for use."
 	}

--- a/json/Item_Stack_FacePaint.txt
+++ b/json/Item_Stack_FacePaint.txt
@@ -4405,7 +4405,7 @@
 	{
 		"assign": "325010044",
 		"jp_text": "ヨーエンメイク/2",
-		"tr_text": "Alluring Makeup /2",
+		"tr_text": "Alluring Makeup/2",
 		"jp_explain": "使用すると新しいメイクパターンが\n選択可能になる。",
 		"tr_explain": "Unlocks a new makeup for use."
 	},

--- a/json/UI_Text.txt
+++ b/json/UI_Text.txt
@@ -10842,7 +10842,7 @@
 	{
 		"assign": "chip_over_num_recycle",
 		"jp_text": "このチップを交換すると\n<color=red><%chip_over>枚</color>オーバーしてしまいます。\n\nチップパックを拡張するか\n強化／売却をしてチップを整理してください。",
-		"tr_text": "Exchanging for this chip will leave you\n<color=red><%chip_over> chips</color> over your limit.\n\nPlease either expand your chip storage or get rid\nof chips by selling them or using them for grinding."
+		"tr_text": "Exchanging for this chip will leave you\n<color=red><%chip_over> chips</color> over your limit.\n\nPlease either expand your Chip Storage or get rid\nof chips by selling them or using them for grinding."
 	},
 	{
 		"assign": "point_over_num_recycle",
@@ -19907,12 +19907,12 @@
 	{
 		"assign": "chip_depot_over_num_leave",
 		"jp_text": "預けるチップ倉庫に空き容量がありません。\n\nチップ倉庫を拡張するか\n強化／売却をして整理してください。\n<color=red><%chip_over>枚</color>オーバーしてしまいます。",
-		"tr_text": "You don't have enough space in your chip storage\nto make this deposit.\nEither expand your chip storage or make room\nby selling chips or using them as grind material.\nExtra space needed: <color=red><%chip_over></color>"
+		"tr_text": "You don't have enough space in your Chip Storage\nto make this deposit.\nEither expand your Chip Storage or make room\nby selling chips or using them as grind material.\nExtra space needed: <color=red><%chip_over></color>"
 	},
 	{
 		"assign": "chip_depot_over_num_leave_max",
 		"jp_text": "預けるチップ倉庫に空き容量がありません。\n\nチップを強化／売却して整理してください。\n<color=red><%chip_over>枚</color>オーバーしてしまいます。",
-		"tr_text": "You don't have enough space in your chip storage\nto make this deposit.\nMake room by selling chips or using them as grind material.\nExtra space needed: <color=red><%chip_over></color>"
+		"tr_text": "You don't have enough space in your Chip Storage\nto make this deposit.\nMake room by selling chips or using them as grind material.\nExtra space needed: <color=red><%chip_over></color>"
 	},
 	{
 		"assign": "chip_depot_over_num_take",


### PR DESCRIPTION
-Add and translate motion.
Added the scratch count bonus motion Dash: Ninja. 7 lines added.

-Fix accessory name.
Fixed typo in Stylia Headgear accessory from the Stylia set.

-Fix item names.
Fixed slash spacing in item names.

-Fix Chip Storage.
Capitalized Chip Storage.