### PR TITLE
PSO2es EN: Fix Idola Mag name.

### DIFF
--- a/json/Item_Stack_DeviceHT.txt
+++ b/json/Item_Stack_DeviceHT.txt
@@ -2494,9 +2494,9 @@
 	{
 		"assign": "3120189",
 		"jp_text": "進化デバイス／パイ",
-		"tr_text": "Evo. Device/Pi",
+		"tr_text": "Evo. Device/Pai",
 		"jp_explain": "Ｌｖ．１００以上のマグに使用できる\nマグの形態進化デバイス。\n「パイ」に進化する。",
-		"tr_explain": "Requires a Lv.100 Mag or above to\nuse. Evolves your Mag into a\nPi."
+		"tr_explain": "Requires a Lv.100 Mag or above to\nuse. Evolves your Mag into a\nPai."
 	},
 	{
 		"assign": "312020189",

--- a/json/Name_Actor_MagName.txt
+++ b/json/Name_Actor_MagName.txt
@@ -562,7 +562,7 @@
 	{
 		"assign": "4189",
 		"jp_text": "パイ",
-		"tr_text": "Pi"
+		"tr_text": "Pai"
 	},
 	{
 		"assign": "419",


### PR DESCRIPTION
Fix the name of Uly's Mag to Pai.