### PR TITLE
EN: Gathering mat and trigger name fixes

### DIFF
--- a/json/Item_Stack_GatCMatFruit.txt
+++ b/json/Item_Stack_GatCMatFruit.txt
@@ -51,119 +51,119 @@
 	{
 		"assign": "354010002",
 		"jp_text": "マッタ・エアルアッポウ",
-		"tr_text": "Nourishing Aelio Apple",
+		"tr_text": "Nourishing Ael Apple",
 		"jp_explain": "エアリオで採取可能な果物。\nPP増加／\nPP消費量軽減",
 		"tr_explain": "Fruit Gathered in Aelio.\nBoosts PP and\nreduces PP consumption."
 	},
 	{
 		"assign": "354010003",
 		"jp_text": "サッパ・エアルピッチ",
-		"tr_text": "Refreshing Aelio Peach",
+		"tr_text": "Refreshing Ael Peach",
 		"jp_explain": "エアリオで採取可能な果物。\nPP増加／\nPP回復量増加",
 		"tr_explain": "Fruit Gathered in Aelio.\nBoosts PP and\nboosts PP recovery."
 	},
 	{
 		"assign": "354010004",
 		"jp_text": "シャッキ・エアルナッシィ",
-		"tr_text": "Sharp Aelio Pear",
+		"tr_text": "Sharp Ael Pear",
 		"jp_explain": "エアリオで採取可能な果物。\nPP増加／\n弱点部位ダメージ増加",
 		"tr_explain": "Fruit Gathered in Aelio.\nBoosts PP and\nboosts weakness damage."
 	},
 	{
 		"assign": "354010005",
 		"jp_text": "ガッツ・エアルバナン",
-		"tr_text": "Healthy Aelio Banana",
+		"tr_text": "Healthy Ael Banana",
 		"jp_explain": "エアリオで採取可能な果物。\nPP増加／\nHP回復量増加",
 		"tr_explain": "Fruit Gathered in Aelio.\nBoosts PP and\nboosts HP recovery."
 	},
 	{
 		"assign": "354010006",
 		"jp_text": "ガッツ・リテナストロンベリ",
-		"tr_text": "Healthy Retem Strawberry",
+		"tr_text": "Healthy Retena Strawberry",
 		"jp_explain": "リテムで採取可能な果物。\nPP増加／\nHP回復量増加",
 		"tr_explain": "Fruit Gathered in Retem.\nBoosts PP and\nboosts HP recovery."
 	},
 	{
 		"assign": "354010007",
 		"jp_text": "マッタ・リテナッチェリ",
-		"tr_text": "Nourishing Retem Cherries",
+		"tr_text": "Nourishing Retena Cherries",
 		"jp_explain": "リテムで採取可能な果物。\nPP増加／\nPP消費量軽減",
 		"tr_explain": "Fruit Gathered in Retem.\nBoosts PP and\nreduces PP consumption."
 	},
 	{
 		"assign": "354010008",
 		"jp_text": "シャッキ・リテナスターツ",
-		"tr_text": "Sharp Retem Star Fruit",
+		"tr_text": "Sharp Retena Star Fruit",
 		"jp_explain": "リテムで採取可能な果物。\nPP増加／\n弱点部位ダメージ増加",
 		"tr_explain": "Fruit Gathered in Retem.\nBoosts PP and\nboosts weakness damage."
 	},
 	{
 		"assign": "354010009",
 		"jp_text": "サッパ・リテナマルゴー",
-		"tr_text": "Refreshing Retem Mango",
+		"tr_text": "Refreshing Retena Mango",
 		"jp_explain": "リテムで採取可能な果物。\nPP増加／\nPP回復量増加",
 		"tr_explain": "Fruit Gathered in Retem.\nBoosts PP and\nboosts PP recovery."
 	},
 	{
 		"assign": "354010010",
 		"jp_text": "マッタ・クヴァルガッキー",
-		"tr_text": "Nourishing Kvaris Ackee",
+		"tr_text": "Nourishing Kvar Ackee",
 		"jp_explain": "クヴァリスで採取可能な果物。\nPP増加／PP消費量軽減／\n低温ダメージ耐性",
 		"tr_explain": "Fruit Gathered in Kvaris.\nBoosts PP, cuts PP consumption and\nboosts cold resistance."
 	},
 	{
 		"assign": "354010011",
 		"jp_text": "サッパ・クヴァルプラーム",
-		"tr_text": "Refreshing Kvaris Plum",
+		"tr_text": "Refreshing Kvar Plum",
 		"jp_explain": "クヴァリスで採取可能な果物。\nPP増加／PP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Fruit Gathered in Kvaris.\nBoosts PP, boosts PP recovery and\nboosts cold resistance."
 	},
 	{
 		"assign": "354010012",
 		"jp_text": "シャッキ・クヴァルグァバー",
-		"tr_text": "Sharp Kvaris Guava",
+		"tr_text": "Sharp Kvar Guava",
 		"jp_explain": "クヴァリスで採取可能な果物。\nPP増加／弱点部位ダメージ増加／\n低温ダメージ耐性",
 		"tr_explain": "Fruit Gathered in Kvaris.\nBoosts PP, boosts weakness damage\nand boosts cold resistance."
 	},
 	{
 		"assign": "354010013",
 		"jp_text": "ガッツ・クヴァルアッケビル",
-		"tr_text": "Healthy Kvaris Akebia",
+		"tr_text": "Healthy Kvar Akebia",
 		"jp_explain": "クヴァリスで採取可能な果物。\nPP増加／HP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Fruit Gathered in Kvaris.\nBoosts PP, boosts HP recovery and\nboosts cold resistance."
 	},
 	{
 		"assign": "354010014",
 		"jp_text": "ノータ・クヴァルガッキー",
-		"tr_text": "Notable Kvaris Ackee",
+		"tr_text": "Notable Kvar Ackee",
 		"jp_explain": "クヴァリスで採取可能な希少な果物。\n特定の場所でアイテムと交換できる。\n<yellow>※クイックフードの効果は\n　マッタ・クヴァルガッキーと同一<c>",
-		"tr_explain": "Rare Fruit Gathered in Kvaris.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Nourishing Kvaris Ackee<c>"
+		"tr_explain": "Rare Fruit Gathered in Kvaris.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Nourishing Kvar Ackee<c>"
 	},
 	{
 		"assign": "354010015",
 		"jp_text": "マッタ・スティラバナン",
-		"tr_text": "Nourishing Stia Banana",
+		"tr_text": "Nourishing Stira Banana",
 		"jp_explain": "スティアで採取可能な果物。\nPP増加／\nPP消費量軽減",
 		"tr_explain": "Fruit Gathered in Stia.\nBoosts PP and\nreduces PP consumption."
 	},
 	{
 		"assign": "354010016",
 		"jp_text": "サッパ・スティラアッポウ",
-		"tr_text": "Refreshing Stia Apple",
+		"tr_text": "Refreshing Stira Apple",
 		"jp_explain": "スティアで採取可能な果物。\nPP増加／\nPP回復量増加",
 		"tr_explain": "Fruit Gathered in Stia.\nBoosts PP and\nboosts PP recovery."
 	},
 	{
 		"assign": "354010017",
 		"jp_text": "シャッキ・スティラマルゴー",
-		"tr_text": "Sharp Stia Mango",
+		"tr_text": "Sharp Stira Mango",
 		"jp_explain": "スティアで採取可能な果物。\nPP増加／\n弱点部位ダメージ増加",
 		"tr_explain": "Fruit Gathered in Stia.\nBoosts PP and\nboosts weakness damage."
 	},
 	{
 		"assign": "354010018",
 		"jp_text": "ガッツ・スティラプラーム",
-		"tr_text": "Healthy Stia Plum",
+		"tr_text": "Healthy Stira Plum",
 		"jp_explain": "スティアで採取可能な果物。\nPP増加／\nHP回復量増加",
 		"tr_explain": "Fruit Gathered in Stia.\nBoosts PP and\nboosts HP recovery."
 	},
@@ -177,8 +177,8 @@
 	{
 		"assign": "354010019",
 		"jp_text": "フェイ・スティラスターツ",
-		"tr_text": "Famed Stia Star Fruit",
+		"tr_text": "Famed Stira Star Fruit",
 		"jp_explain": "スティアで採取可能な希少な果物。\n特定の場所でアイテムと交換できる。\n<yellow>※クイックフードの効果は\n　サッパ・スティラアッポウと同一<c>",
-		"tr_explain": "Rare Fruit Gathered in Stia.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Refreshing Stia Apple<c>"
+		"tr_explain": "Rare Fruit Gathered in Stia.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Refreshing Stira Apple<c>"
 	}
 ]

--- a/json/Item_Stack_GatCMatVegetable.txt
+++ b/json/Item_Stack_GatCMatVegetable.txt
@@ -156,112 +156,112 @@
 	{
 		"assign": "353010002",
 		"jp_text": "ガッツ・エアルカブラナ",
-		"tr_text": "Healthy Aelio Turnip",
+		"tr_text": "Healthy Ael Turnip",
 		"jp_explain": "エアリオで採取可能な野菜。\nダメージ耐性／\nHP回復量増加",
 		"tr_explain": "Vegetable Gathered in Aelio.\nBoosts damage resistance and\nboosts HP recovery."
 	},
 	{
 		"assign": "353010003",
 		"jp_text": "マッタ・エアルハーヴ",
-		"tr_text": "Nourishing Aelio Herb",
+		"tr_text": "Nourishing Ael Herb",
 		"jp_explain": "エアリオで採取可能な野菜。\nダメージ耐性／\nPP消費量軽減",
 		"tr_explain": "Vegetable Gathered in Aelio.\nBoosts damage resistance and\nreduces PP consumption."
 	},
 	{
 		"assign": "353010004",
 		"jp_text": "シャッキ・エアルトマーテ",
-		"tr_text": "Sharp Aelio Tomato",
+		"tr_text": "Sharp Ael Tomato",
 		"jp_explain": "エアリオで採取可能な野菜。\nダメージ耐性／\n弱点部位ダメージ増加",
 		"tr_explain": "Vegetable Gathered in Aelio.\nBoosts damage resistance and\nboosts weakness damage."
 	},
 	{
 		"assign": "353010005",
 		"jp_text": "サッパ・エアルマシュル",
-		"tr_text": "Refreshing Aelio Mushroom",
+		"tr_text": "Refreshing Ael Mushroom",
 		"jp_explain": "エアリオで採取可能な野菜。\nダメージ耐性／\nPP回復量増加",
 		"tr_explain": "Vegetable Gathered in Aelio.\nBoosts damage resistance and\nboosts PP recovery."
 	},
 	{
 		"assign": "353010006",
 		"jp_text": "ガッツ・リテナキャリブラ",
-		"tr_text": "Healthy Retem Cauliflower",
+		"tr_text": "Healthy Retena Cauliflower",
 		"jp_explain": "リテムで採取可能な野菜。\nダメージ耐性／\nHP回復量増加",
 		"tr_explain": "Vegetable Gathered in Retem.\nBoosts damage resistance and\nboosts HP recovery."
 	},
 	{
 		"assign": "353010007",
 		"jp_text": "マッタ・リテナマルナース",
-		"tr_text": "Nourishing Retem Eggplant",
+		"tr_text": "Nourishing Retena Eggplant",
 		"jp_explain": "リテムで採取可能な野菜。\nダメージ耐性／\nPP消費量軽減",
 		"tr_explain": "Vegetable Gathered in Retem.\nBoosts damage resistance and\nreduces PP consumption."
 	},
 	{
 		"assign": "353010008",
 		"jp_text": "シャッキ・リテナマシュル",
-		"tr_text": "Sharp Retem Mushroom",
+		"tr_text": "Sharp Retena Mushroom",
 		"jp_explain": "リテムで採取可能な野菜。\nダメージ耐性／\n弱点部位ダメージ増加",
 		"tr_explain": "Vegetable Gathered in Retem.\nBoosts damage resistance and\nboosts weakness damage."
 	},
 	{
 		"assign": "353010009",
 		"jp_text": "サッパ・リテナクランベ",
-		"tr_text": "Refreshing Retem Cranberries",
+		"tr_text": "Refreshing Retena Cranberries",
 		"jp_explain": "リテムで採取可能な野菜。\nダメージ耐性／\nPP回復量増加",
 		"tr_explain": "Vegetable Gathered in Retem.\nBoosts damage resistance and\nboosts PP recovery."
 	},
 	{
 		"assign": "353010010",
 		"jp_text": "マッタ・クヴァルキャロツ",
-		"tr_text": "Nourishing Kvaris Carrot",
+		"tr_text": "Nourishing Kvar Carrot",
 		"jp_explain": "クヴァリスで採取可能な野菜。\nダメージ耐性／PP消費量軽減／\n低温ダメージ耐性",
 		"tr_explain": "Vegetable Gathered in Kvaris.\nBoosts damage resistance, cuts PP\nconsumption and boosts cold resist."
 	},
 	{
 		"assign": "353010011",
 		"jp_text": "サッパ・クヴァルナッパー",
-		"tr_text": "Refreshing Kvaris Napa",
+		"tr_text": "Refreshing Kvar Napa",
 		"jp_explain": "クヴァリスで採取可能な野菜。\nダメージ耐性／PP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Vegetable Gathered in Kvaris.\nBoosts damage resistance, PP\nrecovery and cold resistance."
 	},
 	{
 		"assign": "353010012",
 		"jp_text": "シャッキ・クヴァルマシュル",
-		"tr_text": "Sharp Kvaris Mushroom",
+		"tr_text": "Sharp Kvar Mushroom",
 		"jp_explain": "クヴァリスで採取可能な野菜。\nダメージ耐性／弱点部位ダメージ増加／\n低温ダメージ耐性",
 		"tr_explain": "Vegetable Gathered in Kvaris.\nBoosts damage resistance, weakness\ndamage and cold resistance."
 	},
 	{
 		"assign": "353010013",
 		"jp_text": "ガッツ・クヴァルオニョン",
-		"tr_text": "Healthy Kvaris Onion",
+		"tr_text": "Healthy Kvar Onion",
 		"jp_explain": "クヴァリスで採取可能な野菜。\nダメージ耐性／HP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Vegetable Gathered in Kvaris.\nBoosts damage resistance, HP\nrecovery and cold resistance."
 	},
 	{
 		"assign": "353010014",
 		"jp_text": "ガッツ・スティラナッパー",
-		"tr_text": "Healthy Stia Napa",
+		"tr_text": "Healthy Stira Napa",
 		"jp_explain": "スティアで採取可能な野菜。\nダメージ耐性／\nHP回復量増加",
 		"tr_explain": "Vegetable Gathered in Stia.\nBoosts damage resistance and\nboosts HP recovery."
 	},
 	{
 		"assign": "353010015",
 		"jp_text": "マッタ・スティラハーヴ",
-		"tr_text": "Nourishing Stia Herb",
+		"tr_text": "Nourishing Stira Herb",
 		"jp_explain": "スティアで採取可能な野菜。\nダメージ耐性／\nPP消費量軽減",
 		"tr_explain": "Vegetable Gathered in Stia.\nBoosts damage resistance and\nreduces PP consumption."
 	},
 	{
 		"assign": "353010016",
 		"jp_text": "シャッキ・スティラキャリブラ",
-		"tr_text": "Sharp Stia Cauliflower",
+		"tr_text": "Sharp Stira Cauliflower",
 		"jp_explain": "スティアで採取可能な野菜。\nダメージ耐性／\n弱点部位ダメージ増加",
 		"tr_explain": "Vegetable Gathered in Stia.\nBoosts damage resistance and\nboosts weakness damage."
 	},
 	{
 		"assign": "353010017",
 		"jp_text": "サッパ・スティラトマーテ",
-		"tr_text": "Refreshing Stia Tomato",
+		"tr_text": "Refreshing Stira Tomato",
 		"jp_explain": "スティアで採取可能な野菜。\nダメージ耐性／\nPP回復量増加",
 		"tr_explain": "Vegetable Gathered in Stia.\nBoosts damage resistance and\nboosts PP recovery."
 	},
@@ -289,8 +289,8 @@
 	{
 		"assign": "353010105",
 		"jp_text": "フェイ・スティラマシュル",
-		"tr_text": "Famed Stia Mushroom",
+		"tr_text": "Famed Stira Mushroom",
 		"jp_explain": "スティアで採取可能な希少な野菜。\n特定の場所でアイテムと交換できる。\n<yellow>※クィックフード効果は\n　シャッキ・スティラキャリブラと同一<c>",
-		"tr_explain": "Rare Vegetable Gathered in Stia.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Sharp Stia Cauliflower<c>"
+		"tr_explain": "Rare Vegetable Gathered in Stia.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Sharp Stira Cauliflower<c>"
 	}
 ]

--- a/json/Item_Stack_GatFMatShellfish.txt
+++ b/json/Item_Stack_GatFMatShellfish.txt
@@ -72,127 +72,127 @@
 	{
 		"assign": "363010002",
 		"jp_text": "マッタ・エアルアザーリ",
-		"tr_text": "Nourishing Aelio Clam",
+		"tr_text": "Nourishing Ael Clam",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\nPP消費量軽減",
 		"tr_explain": "Seafood caught in Aelio.\nBoosts HP and\nreduces PP consumption."
 	},
 	{
 		"assign": "363010003",
 		"jp_text": "サッパ・エアルサザイエ",
-		"tr_text": "Refreshing Aelio Snail",
+		"tr_text": "Refreshing Ael Snail",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\nPP回復量増加",
 		"tr_explain": "Seafood caught in Aelio.\nBoosts HP and\nboosts PP recovery."
 	},
 	{
 		"assign": "363010004",
 		"jp_text": "シャッキ・エアルクラーブ",
-		"tr_text": "Sharp Aelio Crab",
+		"tr_text": "Sharp Ael Crab",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\n弱点部位ダメージ増加",
 		"tr_explain": "Seafood caught in Aelio.\nBoosts HP and\nboosts weakness damage."
 	},
 	{
 		"assign": "363010005",
 		"jp_text": "ガッツ・エアルローブス",
-		"tr_text": "Healthy Aelio Lobster",
+		"tr_text": "Healthy Ael Lobster",
 		"jp_explain": "エアリオで採捕可能な魚介。\nHP増加／\nHP回復量増加",
 		"tr_explain": "Seafood caught in Aelio.\nBoosts HP and\nboosts HP recovery."
 	},
 	{
 		"assign": "363010006",
 		"jp_text": "ガッツ・リテナヤドガーリ",
-		"tr_text": "Healthy Retem Hermit Crab",
+		"tr_text": "Healthy Retena Hermit Crab",
 		"jp_explain": "リテムで採捕可能な魚介。\nHP増加／\nHP回復量増加",
 		"tr_explain": "Seafood caught in Retem.\nBoosts HP and\nboosts HP recovery."
 	},
 	{
 		"assign": "363010007",
 		"jp_text": "マッタ・リテナボタッテ",
-		"tr_text": "Nourishing Retem Scallop",
+		"tr_text": "Nourishing Retena Scallop",
 		"jp_explain": "リテムで採捕可能な魚介。\nHP増加／\nPP消費量軽減",
 		"tr_explain": "Seafood caught in Retem.\nBoosts HP and\nreduces PP consumption."
 	},
 	{
 		"assign": "363010008",
 		"jp_text": "シャッキ・リテナウーニィ",
-		"tr_text": "Sharp Retem Sea Urchin",
+		"tr_text": "Sharp Retena Sea Urchin",
 		"jp_explain": "リテムで採捕可能な魚介。\nHP増加／\n弱点部位ダメージ増加",
 		"tr_explain": "Seafood caught in Retem.\nBoosts HP and\nboosts weakness damage."
 	},
 	{
 		"assign": "363010009",
 		"jp_text": "サッパ・リテナウミッシー",
-		"tr_text": "Refreshing Retem Sea Slug",
+		"tr_text": "Refreshing Retena Sea Slug",
 		"jp_explain": "リテムで採捕可能な魚介。\nHP増加／\nPP回復量増加",
 		"tr_explain": "Seafood caught in Retem.\nBoosts HP and\nboosts PP recovery."
 	},
 	{
 		"assign": "363010010",
 		"jp_text": "マッタ・クヴァルマギカイ",
-		"tr_text": "Nourishing Kvaris Sea Snail",
+		"tr_text": "Nourishing Kvar Sea Snail",
 		"jp_explain": "クヴァリスで採捕可能な魚介。\nHP増加／PP消費量軽減／\n低温ダメージ耐性",
 		"tr_explain": "Seafood caught in Kvaris.\nBoosts HP, reduces PP consumption\nand boosts cold resistance."
 	},
 	{
 		"assign": "363010011",
 		"jp_text": "サッパ・クヴァルオクトヴァ",
-		"tr_text": "Refreshing Kvaris Octopus",
+		"tr_text": "Refreshing Kvar Octopus",
 		"jp_explain": "クヴァリスで採捕可能な魚介。\nHP増加／PP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Seafood caught in Kvaris.\nBoosts HP, boosts PP recovery and\nboosts cold resistance."
 	},
 	{
 		"assign": "363010012",
 		"jp_text": "シャッキ・クヴァルスクイド",
-		"tr_text": "Sharp Kvaris Squid",
+		"tr_text": "Sharp Kvar Squid",
 		"jp_explain": "クヴァリスで採捕可能な魚介。\nHP増加／弱点部位ダメージ増加／\n低温ダメージ耐性",
 		"tr_explain": "Seafood caught in Kvaris.\nBoosts HP, boosts weakness damage\nand boosts cold resistance."
 	},
 	{
 		"assign": "363010013",
 		"jp_text": "ガッツ・クヴァルザリーニ",
-		"tr_text": "Healthy Kvaris Lobster",
+		"tr_text": "Healthy Kvar Lobster",
 		"jp_explain": "クヴァリスで採捕可能な魚介。\nHP増加／HP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Seafood caught in Kvaris.\nBoosts HP, boosts HP recovery and\nboosts cold resistance."
 	},
 	{
 		"assign": "363010014",
 		"jp_text": "ノータ・クヴァルスクイド",
-		"tr_text": "Notable Kvaris Squid",
+		"tr_text": "Notable Kvar Squid",
 		"jp_explain": "クヴァリスで採捕可能な希少な魚介。\n特定の場所でアイテムと交換できる。\n<yellow>※クイックフードの効果は\n　シャッキ・クヴァルスクイドと同一<c>",
-		"tr_explain": "Rare Seafood caught in Kvaris.\nCan be traded for items.\n<yellow>When used in Quick Food, has the\nsame effect as Sharp Kvaris Squid<c>"
+		"tr_explain": "Rare Seafood caught in Kvaris.\nCan be traded for items.\n<yellow>When used in Quick Food, has the\nsame effect as Sharp Kvar Squid<c>"
 	},
 	{
 		"assign": "363010015",
 		"jp_text": "マッタ・スティラヤドガーリ",
-		"tr_text": "Nourishing Stia Hermit Crab",
+		"tr_text": "Nourishing Stira Hermit Crab",
 		"jp_explain": "スティアで採捕可能な魚介。\nHP増加／\nPP消費量軽減",
 		"tr_explain": "Seafood caught in Stia.\nBoosts HP and\nreduces PP consumption."
 	},
 	{
 		"assign": "363010016",
 		"jp_text": "サッパ・スティラウミッシー",
-		"tr_text": "Refreshing Stia Sea Slug",
+		"tr_text": "Refreshing Stira Sea Slug",
 		"jp_explain": "スティアで採捕可能な魚介。\nHP増加／\nPP回復量増加",
 		"tr_explain": "Seafood caught in Stia.\nBoosts HP and\nboosts PP recovery."
 	},
 	{
 		"assign": "363010017",
 		"jp_text": "シャッキ・スティラオクトヴァ",
-		"tr_text": "Sharp Stia Octopus",
+		"tr_text": "Sharp Stira Octopus",
 		"jp_explain": "スティアで採捕可能な魚介。\nHP増加／\n弱点部位ダメージ増加",
 		"tr_explain": "Seafood caught in Stia.\nBoosts HP and\nboosts weakness damage."
 	},
 	{
 		"assign": "363010018",
 		"jp_text": "ガッツ・スティラサザイエ",
-		"tr_text": "Healthy Stia Snail",
+		"tr_text": "Healthy Stira Snail",
 		"jp_explain": "スティアで採捕可能な魚介。\nHP増加／\nHP回復量増加",
 		"tr_explain": "Seafood caught in Stia.\nBoosts HP and\nboosts HP recovery."
 	},
 	{
 		"assign": "363010019",
 		"jp_text": "フェイ・スティラクラーブ",
-		"tr_text": "Famed Stia Crab",
+		"tr_text": "Famed Stira Crab",
 		"jp_explain": "スティアで採捕可能な希少な魚介。\n特定の場所でアイテムと交換できる。\n<yellow>※クィックフード効果は\n　マッタ・スティラヤドガーリと同一<c>",
-		"tr_explain": "Rare Seafood Gathered in Stia.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Nourishing Stia Hermit Crab<c>"
+		"tr_explain": "Rare Seafood Gathered in Stia.\nCan be traded for items.\n<yellow>When used in Quick Food, has same\neffect as Nourishing Stira Hermit Crab<c>"
 	}
 ]

--- a/json/Item_Stack_GatOMatMeat.txt
+++ b/json/Item_Stack_GatOMatMeat.txt
@@ -16,119 +16,119 @@
 	{
 		"assign": "370010002",
 		"jp_text": "シャッキ・エアル肉",
-		"tr_text": "Sharp Aelio Meat",
+		"tr_text": "Sharp Ael Meat",
 		"jp_explain": "エアリオで入手可能な肉。\n威力上昇／\n弱点部位ダメージ増加",
 		"tr_explain": "Meat obtained in Aelio.\nBoosts damage and\nboosts weakness damage."
 	},
 	{
 		"assign": "370010003",
 		"jp_text": "ガッツ・エアル肉",
-		"tr_text": "Healthy Aelio Meat",
+		"tr_text": "Healthy Ael Meat",
 		"jp_explain": "エアリオで入手可能な肉。\n威力上昇／\nHP回復量増加",
 		"tr_explain": "Meat obtained in Aelio.\nBoosts damage and\nboosts HP recovery."
 	},
 	{
 		"assign": "370010004",
 		"jp_text": "サッパ・エアル肉",
-		"tr_text": "Refreshing Aelio Meat",
+		"tr_text": "Refreshing Ael Meat",
 		"jp_explain": "エアリオで入手可能な肉。\n威力上昇／\nPP回復量増加",
 		"tr_explain": "Meat obtained in Aelio.\nBoosts damage and\nboosts PP recovery."
 	},
 	{
 		"assign": "370010005",
 		"jp_text": "マッタ・エアル肉",
-		"tr_text": "Nourishing Aelio Meat",
+		"tr_text": "Nourishing Ael Meat",
 		"jp_explain": "エアリオで入手可能な肉。\n威力上昇／\nPP消費量軽減",
 		"tr_explain": "Meat obtained in Aelio.\nBoosts damage and\nreduces PP consumption."
 	},
 	{
 		"assign": "370010006",
 		"jp_text": "シャッキ・リテナ肉",
-		"tr_text": "Sharp Retem Meat",
+		"tr_text": "Sharp Retena Meat",
 		"jp_explain": "リテムで入手可能な肉。\n威力上昇／\n弱点部位ダメージ増加",
 		"tr_explain": "Meat obtained in Retem.\nBoosts damage and\nboosts weakness damage."
 	},
 	{
 		"assign": "370010007",
 		"jp_text": "ガッツ・リテナ肉",
-		"tr_text": "Healthy Retem Meat",
+		"tr_text": "Healthy Retena Meat",
 		"jp_explain": "リテムで入手可能な肉。\n威力上昇／\nHP回復量増加",
 		"tr_explain": "Meat obtained in Retem.\nBoosts damage and\nboosts HP recovery."
 	},
 	{
 		"assign": "370010008",
 		"jp_text": "サッパ・リテナ肉",
-		"tr_text": "Refreshing Retem Meat",
+		"tr_text": "Refreshing Retena Meat",
 		"jp_explain": "リテムで入手可能な肉。\n威力上昇／\nPP回復量増加",
 		"tr_explain": "Meat obtained in Retem.\nBoosts damage and\nboosts PP recovery."
 	},
 	{
 		"assign": "370010009",
 		"jp_text": "マッタ・リテナ肉",
-		"tr_text": "Nourishing Retem Meat",
+		"tr_text": "Nourishing Retena Meat",
 		"jp_explain": "リテムで入手可能な肉。\n威力上昇／\nPP消費量軽減",
 		"tr_explain": "Meat obtained in Retem.\nBoosts damage and\nreduces PP consumption."
 	},
 	{
 		"assign": "370010010",
 		"jp_text": "マッタ・クヴァル肉",
-		"tr_text": "Nourishing Kvaris Meat",
+		"tr_text": "Nourishing Kvar Meat",
 		"jp_explain": "クヴァリスで入手可能な肉。\n威力上昇／PP消費量軽減／\n低温ダメージ耐性",
 		"tr_explain": "Meat obtained in Kvaris.\nBoosts damage, cuts PP consumption\nand boosts cold resistance."
 	},
 	{
 		"assign": "370010011",
 		"jp_text": "サッパ・クヴァル肉",
-		"tr_text": "Refreshing Kvaris Meat",
+		"tr_text": "Refreshing Kvar Meat",
 		"jp_explain": "クヴァリスで入手可能な肉。\n威力上昇／PP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Meat obtained in Kvaris.\nBoosts damage, boosts PP recovery\nand boosts cold resistance."
 	},
 	{
 		"assign": "370010012",
 		"jp_text": "シャッキ・クヴァル肉",
-		"tr_text": "Sharp Kvaris Meat",
+		"tr_text": "Sharp Kvar Meat",
 		"jp_explain": "クヴァリスで入手可能な肉。\n威力上昇／弱点部位ダメージ増加／\n低温ダメージ耐性",
 		"tr_explain": "Meat obtained in Kvaris.\nBoosts damage, boosts weakness\ndamage and boosts cold resistance."
 	},
 	{
 		"assign": "370010013",
 		"jp_text": "ガッツ・クヴァル肉",
-		"tr_text": "Healthy Kvaris Meat",
+		"tr_text": "Healthy Kvar Meat",
 		"jp_explain": "クヴァリスで入手可能な肉。\n威力上昇／HP回復量増加／\n低温ダメージ耐性",
 		"tr_explain": "Meat obtained in Kvaris.\nBoosts damage, boosts HP recovery\nand boosts cold resistance."
 	},
 	{
 		"assign": "370010014",
 		"jp_text": "ノータ・クヴァル肉",
-		"tr_text": "Notable Kvaris Meat",
+		"tr_text": "Notable Kvar Meat",
 		"jp_explain": "クヴァリスで入手可能な希少な肉。\n特定の場所でアイテムと交換できる。\n<yellow>※クイックフードの効果は\n　ガッツ・クヴァル肉と同一<c>",
-		"tr_explain": "Rare meat obtained in Kvaris.\nCan be traded for items.\n<yellow>When used in Quick Food, has the\nsame effect as Healthy Kvaris Meat<c>"
+		"tr_explain": "Rare meat obtained in Kvaris.\nCan be traded for items.\n<yellow>When used in Quick Food, has the\nsame effect as Healthy Kvar Meat<c>"
 	},
 	{
 		"assign": "370010015",
 		"jp_text": "ガッツ・スティラ肉",
-		"tr_text": "Healthy Stia Meat",
+		"tr_text": "Healthy Stira Meat",
 		"jp_explain": "スティアで入手可能な肉。\n威力上昇／\nHP回復量増加",
 		"tr_explain": "Meat obtained in Stia.\nBoosts damage and\nboosts HP recovery."
 	},
 	{
 		"assign": "370010016",
 		"jp_text": "サッパ・スティラ肉",
-		"tr_text": "Refreshing Stia Meat",
+		"tr_text": "Refreshing Stira Meat",
 		"jp_explain": "スティアで入手可能な肉。\n威力上昇／\nPP回復量増加",
 		"tr_explain": "Meat obtained in Stia.\nBoosts damage and\nboosts PP recovery."
 	},
 	{
 		"assign": "370010017",
 		"jp_text": "マッタ・スティラ肉",
-		"tr_text": "Nourishing Stia Meat",
+		"tr_text": "Nourishing Stira Meat",
 		"jp_explain": "スティアで入手可能な肉。\n威力上昇／\nPP消費量軽減",
 		"tr_explain": "Meat obtained in Stia.\nBoosts damage and\nreduces PP consumption."
 	},
 	{
 		"assign": "370010018",
 		"jp_text": "シャッキ・スティラ肉",
-		"tr_text": "Sharp Stia Meat",
+		"tr_text": "Sharp Stira Meat",
 		"jp_explain": "スティアで入手可能な肉。\n威力上昇／\n弱点部位ダメージ増加",
 		"tr_explain": "Meat obtained in Stia.\nBoosts damage and\nboosts weakness damage."
 	}

--- a/json/Item_Stack_Tool.txt
+++ b/json/Item_Stack_Tool.txt
@@ -765,14 +765,14 @@
 	{
 		"assign": "37010020",
 		"jp_text": "Bトリガー/エアルイエロー",
-		"tr_text": "B. Trigger/Aelio Yellow",
+		"tr_text": "B. Trigger/Ael Yellow",
 		"jp_explain": "アイテムリサイクルで\n“Bトリガー/コモンイエロー“\nと交換できる。\n<yellow>※Bトリガーとしては使用不可<c>",
 		"tr_explain": "A Trigger used in the Battledia.\nConsumed upon clearing:\n\"Aelio Troopers\"."
 	},
 	{
 		"assign": "37010021",
 		"jp_text": "Bトリガー/エアルパープル",
-		"tr_text": "B. Trigger/Aelio Purple",
+		"tr_text": "B. Trigger/Ael Purple",
 		"jp_explain": "アイテムリサイクルで\n“Bトリガー/コモンパープル“\nと交換できる。\n<yellow>※Bトリガーとしては使用不可<c>",
 		"tr_explain": "A Trigger used in the Battledia.\nConsumed upon clearing:\n\"Aelio Devastators\"."
 	},
@@ -793,14 +793,14 @@
 	{
 		"assign": "37010024",
 		"jp_text": "Bトリガー/リテナイエロー",
-		"tr_text": "B. Trigger/Retem Yellow",
+		"tr_text": "B. Trigger/Retena Yellow",
 		"jp_explain": "アイテムリサイクルで\n“Bトリガー/コモンイエロー“\nと交換できる。\n<yellow>※Bトリガーとしては使用不可<c>",
 		"tr_explain": "A Trigger used in the Battledia.\nConsumed upon clearing:\n\"Retem Troopers\"."
 	},
 	{
 		"assign": "37010025",
 		"jp_text": "Bトリガー/リテナパープル",
-		"tr_text": "B. Trigger/Retem Purple",
+		"tr_text": "B. Trigger/Retena Purple",
 		"jp_explain": "アイテムリサイクルで\n“Bトリガー/コモンパープル“\nと交換できる。\n<yellow>※Bトリガーとしては使用不可<c>",
 		"tr_explain": "A Trigger used in the Battledia.\nConsumed upon clearing:\n\"Retem Devastators\"."
 	},
@@ -905,14 +905,14 @@
 	{
 		"assign": "37010041",
 		"jp_text": "Bトリガー/クヴァルイエロー",
-		"tr_text": "B. Trigger/Kvaris Yellow",
+		"tr_text": "B. Trigger/Kvar Yellow",
 		"jp_explain": "アイテムリサイクルで\n“Bトリガー/コモンイエロー“\nと交換できる。\n<yellow>※Bトリガーとしては使用不可<c>",
 		"tr_explain": "Trigger used at Battledia.\nConsumed upon clearing\n\"Kvaris Troopers\"."
 	},
 	{
 		"assign": "37010042",
 		"jp_text": "Bトリガー/クヴァルパープル",
-		"tr_text": "B. Trigger/Kvaris Purple",
+		"tr_text": "B. Trigger/Kvar Purple",
 		"jp_explain": "アイテムリサイクルで\n“Bトリガー/コモンパープル“\nと交換できる。\n<yellow>※Bトリガーとしては使用不可<c>",
 		"tr_explain": "Trigger used at Battledia.\nConsumed upon clearing\n\"Kvaris Devastators\"."
 	},


### PR DESCRIPTION
Gathering mats, old battle triggers and region affix capsule all have Ael, Retena etc for their regional identifiers. For everything except the affixes, we just translated that as the region's name. This pull request makes them consistent with each other.